### PR TITLE
Replace parallel workers with adaptive rate-limited dispatch queue

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Run backfill ingestion
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: npm run ingest -- --from ${{ inputs.from_season }} --to ${{ inputs.to_season }} --season-concurrency 2 --concurrency 5
+        run: npm run ingest -- --from ${{ inputs.from_season }} --to ${{ inputs.to_season }} --delay 500

--- a/.github/workflows/hourly-update.yml
+++ b/.github/workflows/hourly-update.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run current season ingestion (low concurrency)
+      - name: Run current season ingestion
         env:
           MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
-        run: npm run ingest -- --season ${{ needs.check-season.outputs.season_year }} --concurrency 3
+        run: npm run ingest -- --season ${{ needs.check-season.outputs.season_year }} --delay 500

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "generate-schemas": "tsx scripts/generate-schemas.ts",
     "ingest": "tsx scripts/ingest/index.ts",
     "ingest:current": "tsx scripts/ingest/index.ts --season 2025",
-    "ingest:backfill": "tsx scripts/ingest/index.ts --all --season-concurrency 2 --concurrency 5",
+    "ingest:backfill": "tsx scripts/ingest/index.ts --all --delay 500",
     "ingest:playoffs": "tsx scripts/ingest/index.ts --all --season-type Playoffs",
     "ingest:status": "tsx scripts/ingest/status.ts",
     "data-quality:check": "tsx scripts/data-quality/check.ts",

--- a/scripts/ingest/api/client.ts
+++ b/scripts/ingest/api/client.ts
@@ -1,7 +1,7 @@
 // HTTP client for PBPStats API with retry and backoff
 
 import axios, { type AxiosError } from 'axios';
-import { acquire } from './rate-limiter';
+import { acquire, recordSuccess, recordThrottle } from './rate-limiter';
 import { logger } from '../util/logger';
 import type { PBPStatsBoxScoreResponse, PBPStatsGamesResponse } from '../types';
 
@@ -41,6 +41,7 @@ async function fetchWithRetry<T>(
         headers: DEFAULT_HEADERS,
         signal,
       });
+      recordSuccess();
       return response.data;
     } catch (err) {
       const axErr = err as AxiosError;
@@ -52,6 +53,11 @@ async function fetchWithRetry<T>(
       // Don't retry 4xx errors (except 429 rate limit)
       if (status && status >= 400 && status < 500 && status !== 429) {
         throw err;
+      }
+
+      // Signal throttle for adaptive rate limiting
+      if (status === 429 || status === 503) {
+        recordThrottle();
       }
 
       if (attempt === MAX_RETRIES) throw err;

--- a/scripts/ingest/api/rate-limiter.ts
+++ b/scripts/ingest/api/rate-limiter.ts
@@ -1,23 +1,137 @@
-// Token-bucket rate limiter for API requests
-// Singleton: shared across all workers to enforce global rate limiting
+// Adaptive rate limiter for API request dispatch
+// Singleton: controls the interval between dispatching requests off the queue
+//
+// Multiple requests can be in-flight simultaneously — this only gates
+// how fast we dispatch them.
+//
+// Uses a serializing promise chain so concurrent acquire() calls
+// are queued and each waits the correct interval after the previous.
+//
+// Continuously adapts based on a rolling window of results:
+// - Clean window (0% errors): speed up aggressively
+// - Low error rate (<10%): still speed up gently (isolated errors are normal)
+// - High error rate (>10%): slow down
+// - Always probing: checks every 8 successes, so it recovers quickly
+//   after a transient error and adapts to changing server load
 
-let lastRequestTime = 0;
-let intervalMs = 150;
+import { logger } from '../util/logger';
 
-/** Set the minimum interval between requests (in milliseconds) */
-export function setInterval(ms: number): void {
-  intervalMs = ms;
+let delayMs = 500;
+let minDelayMs = 200;
+let maxDelayMs = 10_000;
+
+// Serializing chain: each acquire() waits for the previous to finish
+let acquireChain = Promise.resolve();
+let lastDispatchTime = 0;
+
+// Rolling window of recent outcomes: true = success, false = throttle
+const WINDOW_SIZE = 15;
+const outcomes: boolean[] = [];
+
+const AGGRESSIVE_SPEEDUP = 0.85; // -15% on clean window
+const GENTLE_SPEEDUP = 0.95; // -5% on mostly-clean window
+const MODERATE_SLOWDOWN = 1.5; // +50% on isolated error
+const AGGRESSIVE_SLOWDOWN = 2.0; // +100% on sustained errors
+const ERROR_RATE_HIGH = 0.1; // >10% triggers aggressive slowdown
+const PROBE_INTERVAL = 8; // check every 8 successes
+
+let successesSinceLastProbe = 0;
+
+/** Configure the adaptive throttle parameters */
+export function configure(opts: {
+  baseDelay?: number;
+  minDelay?: number;
+  maxDelay?: number;
+}): void {
+  if (opts.baseDelay !== undefined) delayMs = opts.baseDelay;
+  if (opts.minDelay !== undefined) minDelayMs = opts.minDelay;
+  if (opts.maxDelay !== undefined) maxDelayMs = opts.maxDelay;
 }
 
-/** Wait until it is safe to make the next request */
-export async function acquire(): Promise<void> {
-  const now = Date.now();
-  const elapsed = now - lastRequestTime;
-  const waitMs = intervalMs - elapsed;
+function pushOutcome(success: boolean): void {
+  outcomes.push(success);
+  if (outcomes.length > WINDOW_SIZE) {
+    outcomes.shift();
+  }
+}
 
-  if (waitMs > 0) {
-    await new Promise(resolve => setTimeout(resolve, waitMs));
+function getErrorRate(): number {
+  if (outcomes.length === 0) return 0;
+  const errors = outcomes.filter(o => !o).length;
+  return errors / outcomes.length;
+}
+
+/**
+ * Wait until it is safe to dispatch the next request.
+ * Serialized: concurrent callers queue up so each waits the
+ * correct interval after the previous dispatch.
+ */
+export async function acquire(): Promise<void> {
+  const ticket = acquireChain.then(async () => {
+    const now = Date.now();
+    const elapsed = now - lastDispatchTime;
+    const waitMs = delayMs - elapsed;
+    if (waitMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, waitMs));
+    }
+    lastDispatchTime = Date.now();
+  });
+  acquireChain = ticket.catch(() => { /* keep chain alive on errors */ });
+  await ticket;
+}
+
+/** Call after a successful API response */
+export function recordSuccess(): void {
+  pushOutcome(true);
+  successesSinceLastProbe++;
+
+  if (successesSinceLastProbe >= PROBE_INTERVAL) {
+    successesSinceLastProbe = 0;
+    const errorRate = getErrorRate();
+    const prev = delayMs;
+
+    if (errorRate === 0 && outcomes.length >= PROBE_INTERVAL) {
+      // Perfectly clean window — aggressive speedup
+      delayMs = Math.max(minDelayMs, Math.round(delayMs * AGGRESSIVE_SPEEDUP));
+    } else if (errorRate < ERROR_RATE_HIGH) {
+      // Mostly clean (isolated errors) — still speed up gently
+      delayMs = Math.max(minDelayMs, Math.round(delayMs * GENTLE_SPEEDUP));
+    }
+    // else: high error rate — hold steady, let slowdowns from recordThrottle handle it
+
+    if (delayMs < prev) {
+      logger.debug('Throttle speedup', {
+        delayMs,
+        previousDelay: prev,
+        errorRate: `${(errorRate * 100).toFixed(0)}%`,
+      });
+    }
+  }
+}
+
+/** Call after a 503/429 to back off */
+export function recordThrottle(): void {
+  pushOutcome(false);
+  // Don't reset successesSinceLastProbe — let the probe fire soon
+  // so we can recover quickly once the errors pass
+
+  const errorRate = getErrorRate();
+  const prev = delayMs;
+
+  if (errorRate > ERROR_RATE_HIGH) {
+    delayMs = Math.min(maxDelayMs, Math.round(delayMs * AGGRESSIVE_SLOWDOWN));
+  } else {
+    delayMs = Math.min(maxDelayMs, Math.round(delayMs * MODERATE_SLOWDOWN));
   }
 
-  lastRequestTime = Date.now();
+  logger.warn('Throttle slowdown', {
+    delayMs,
+    previousDelay: prev,
+    errorRate: `${(errorRate * 100).toFixed(0)}%`,
+  });
+}
+
+/** Get the current dispatch delay */
+export function getCurrentDelay(): number {
+  return delayMs;
 }

--- a/scripts/ingest/config.ts
+++ b/scripts/ingest/config.ts
@@ -3,7 +3,7 @@
 import type { PipelineConfig } from './types';
 
 const USAGE = `
-Usage: tsx scripts/ingest/main.ts [options]
+Usage: tsx scripts/ingest/index.ts [options]
 
 Season selection (at least one required):
   --season <year>               Single season (e.g. 2025 for 2025-26)
@@ -12,8 +12,10 @@ Season selection (at least one required):
 
 Options:
   --season-type <type>          "Regular Season" | "Playoffs"  [default: "Regular Season"]
-  --concurrency <n>             Parallel game workers          [default: 10]
-  --season-concurrency <n>      Parallel season workers        [default: 3]
+  --delay <ms>                  Base delay between API requests [default: 500]
+  --min-delay <ms>              Minimum delay (adaptive floor)  [default: 200]
+  --max-delay <ms>              Maximum delay (adaptive cap)    [default: 10000]
+  --season-concurrency <n>      Parallel season workers         [default: 1]
   --force                       Re-ingest even if already logged
   --dry-run                     Log actions without writing to DB
   --verbose                     Enable debug-level logging
@@ -43,7 +45,9 @@ export function buildConfig(args: string[] = process.argv.slice(2)): PipelineCon
   let to: number | undefined;
   let all = false;
   let seasonType = 'Regular Season';
-  let concurrency = 5;
+  let delay = 500;
+  let minDelay = 200;
+  let maxDelay = 10_000;
   let seasonConcurrency = 1;
   let force = false;
   let dryRun = false;
@@ -92,13 +96,37 @@ export function buildConfig(args: string[] = process.argv.slice(2)): PipelineCon
         seasonType = val;
         break;
       }
-      case '--concurrency': {
+      case '--delay': {
         const val = argv.shift();
-        if (!val) fail('--concurrency requires a value');
-        concurrency = parseInt(val, 10);
-        if (isNaN(concurrency) || concurrency < 1) {
-          fail(`Invalid concurrency: ${val}`);
+        if (!val) fail('--delay requires a value');
+        delay = parseInt(val, 10);
+        if (isNaN(delay) || delay < 0) {
+          fail(`Invalid delay: ${val}`);
         }
+        break;
+      }
+      case '--min-delay': {
+        const val = argv.shift();
+        if (!val) fail('--min-delay requires a value');
+        minDelay = parseInt(val, 10);
+        if (isNaN(minDelay) || minDelay < 0) {
+          fail(`Invalid min-delay: ${val}`);
+        }
+        break;
+      }
+      case '--max-delay': {
+        const val = argv.shift();
+        if (!val) fail('--max-delay requires a value');
+        maxDelay = parseInt(val, 10);
+        if (isNaN(maxDelay) || maxDelay < 0) {
+          fail(`Invalid max-delay: ${val}`);
+        }
+        break;
+      }
+      case '--concurrency': {
+        // Legacy flag — consume value if present, ignore silently
+        const next = argv[0];
+        if (next && !next.startsWith('--')) argv.shift();
         break;
       }
       case '--season-concurrency': {
@@ -148,6 +176,14 @@ export function buildConfig(args: string[] = process.argv.slice(2)): PipelineCon
     fail('At least one of --season, --from/--to, or --all is required');
   }
 
+  // Validate delay bounds
+  if (minDelay > maxDelay) {
+    fail(`--min-delay (${minDelay}) must be <= --max-delay (${maxDelay})`);
+  }
+  if (delay < minDelay || delay > maxDelay) {
+    fail(`--delay (${delay}) must be between --min-delay (${minDelay}) and --max-delay (${maxDelay})`);
+  }
+
   // Validate MOTHERDUCK_TOKEN
   const motherDuckToken = process.env.MOTHERDUCK_TOKEN;
   if (!motherDuckToken) {
@@ -156,7 +192,9 @@ export function buildConfig(args: string[] = process.argv.slice(2)): PipelineCon
 
   return {
     seasons,
-    concurrency,
+    delay,
+    minDelay,
+    maxDelay,
     seasonConcurrency,
     force,
     dryRun,

--- a/scripts/ingest/index.ts
+++ b/scripts/ingest/index.ts
@@ -2,6 +2,7 @@
 // CLI entry point for the v2 NBA box scores ingestion pipeline
 
 import { buildConfig } from './config';
+import { configure } from './api/rate-limiter';
 import { MotherDuckConnection } from './db/connection';
 import { Loader } from './db/loader';
 import { processSeason } from './workers/season-worker';
@@ -17,13 +18,24 @@ async function main(): Promise<void> {
     logger.setVerbose(true);
   }
 
+  // Configure adaptive throttle
+  configure({
+    baseDelay: config.delay,
+    minDelay: config.minDelay,
+    maxDelay: config.maxDelay,
+  });
+
   logger.info('NBA Box Scores Ingestion Pipeline v2', {
     seasons: config.seasons.length,
-    concurrency: config.concurrency,
+    delay: `${config.delay}ms (${config.minDelay}-${config.maxDelay}ms)`,
     seasonConcurrency: config.seasonConcurrency,
     force: config.force,
     dryRun: config.dryRun,
   });
+
+  if (config.seasonConcurrency > 1) {
+    logger.warn('season-concurrency > 1: multiple seasons share one rate limiter, may overshoot API limits');
+  }
 
   // Dry-run: just print what would be processed
   if (config.dryRun) {

--- a/scripts/ingest/types.ts
+++ b/scripts/ingest/types.ts
@@ -118,7 +118,9 @@ export interface SeasonProgress {
 /** Pipeline configuration (output of buildConfig) */
 export interface PipelineConfig {
   seasons: Array<{ year: number; type: string }>;
-  concurrency: number;
+  delay: number;
+  minDelay: number;
+  maxDelay: number;
   seasonConcurrency: number;
   force: boolean;
   dryRun: boolean;

--- a/scripts/ingest/workers/season-worker.ts
+++ b/scripts/ingest/workers/season-worker.ts
@@ -1,16 +1,36 @@
-// Season-level worker: fetches game list, fans out to per-game processing
+// Season-level worker: fetches game list, dispatches games via adaptive queue
+//
+// The dispatch loop sends requests at the adaptive delay interval.
+// Multiple requests can be in-flight simultaneously — the rate limiter
+// only gates how fast we dispatch, not how many are running.
+// Failed games go to the back of the queue for retry.
+//
+// Retry semantics: fetchWithRetry handles transient HTTP errors (5 retries
+// with backoff). The queue-level retry (MAX_GAME_RETRIES) handles errors
+// that survive all HTTP retries (e.g., parse failures, DB errors).
 
 import { getGames, getBoxScore } from '../api/client';
+import { getCurrentDelay } from '../api/rate-limiter';
 import { parseBoxScore } from '../parse/box-score-parser';
 import { Loader } from '../db/loader';
-import { runPool } from './pool';
 import { logger } from '../util/logger';
-import type { PipelineConfig, SeasonProgress, ScheduleRow } from '../types';
+import type { PipelineConfig, SeasonProgress, ScheduleRow, PBPStatsGamesResponse } from '../types';
 
 /** Convert a season start year to the API season string, e.g. 2024 -> "2024-25" */
 function yearToSeason(year: number): string {
   const endYear = (year + 1) % 100;
   return `${year}-${endYear.toString().padStart(2, '0')}`;
+}
+
+// Queue-level retries for errors that survive all HTTP retries in fetchWithRetry
+// (e.g., parse failures, DB errors). Total worst-case attempts per game:
+// MAX_GAME_RETRIES * (MAX_RETRIES + 1) = 3 * 6 = 18 API requests.
+const MAX_GAME_RETRIES = 3;
+const MAX_IN_FLIGHT = 8;
+
+interface QueueItem {
+  game: PBPStatsGamesResponse['results'][number];
+  attempts: number;
 }
 
 /** Process all games for a single (season, seasonType) pair */
@@ -76,7 +96,6 @@ export async function processSeason(
   });
 
   if (config.dryRun) {
-    // In dry-run mode, count all remaining as "would process"
     return progress;
   }
 
@@ -96,27 +115,46 @@ export async function processSeason(
   }));
   await loader.loadScheduleRows(scheduleRows);
 
-  // 5. Fan out to per-game processing via runPool
-  await runPool(
-    gamesToProcess,
-    async (game, sig) => {
-      const gameId = game.GameId;
+  // 5. Adaptive dispatch loop: fire requests at tuned intervals, multiple in-flight
+  const queue: QueueItem[] = gamesToProcess.map((game) => ({ game, attempts: 0 }));
+  const totalToProcess = queue.length;
+  const startTime = Date.now();
 
-      // Fetch box score from API
-      const boxScoreResponse = await getBoxScore(gameId, sig);
+  // Track in-flight promises; each removes itself on settlement
+  const inFlight = new Set<Promise<void>>();
 
-      // Build the shape parseBoxScore expects
+  function logProgress(): void {
+    const elapsed = (Date.now() - startTime) / 1000;
+    const done = progress.completed + progress.failed;
+    const gamesPerMin = elapsed > 0 ? (done / elapsed) * 60 : 0;
+    const remaining = totalToProcess - done;
+    const eta = gamesPerMin > 0 ? Math.round(remaining / gamesPerMin) : '?';
+
+    logger.progress(
+      `[${season}] ${done}/${totalToProcess} ` +
+      `(${progress.completed} ok, ${progress.failed} err) ` +
+      `${gamesPerMin.toFixed(1)}/min, delay=${getCurrentDelay()}ms, ` +
+      `inflight=${inFlight.size}, ETA ${eta}min`,
+    );
+  }
+
+  function dispatch(item: QueueItem): void {
+    const gameId = item.game.GameId;
+
+    const promise = (async () => {
+      const boxScoreResponse = await getBoxScore(gameId, signal);
+
       const rawGameData = {
         game: {
           gameId,
-          gameDateEst: game.Date,
+          gameDateEst: item.game.Date,
           homeTeam: {
-            teamId: parseInt(game.HomeTeamId, 10),
-            teamTricode: game.HomeTeamAbbreviation,
+            teamId: parseInt(item.game.HomeTeamId, 10),
+            teamTricode: item.game.HomeTeamAbbreviation,
           },
           awayTeam: {
-            teamId: parseInt(game.AwayTeamId, 10),
-            teamTricode: game.AwayTeamAbbreviation,
+            teamId: parseInt(item.game.AwayTeamId, 10),
+            teamTricode: item.game.AwayTeamAbbreviation,
           },
         },
         boxScore: {
@@ -124,13 +162,8 @@ export async function processSeason(
         },
       };
 
-      // Parse into BoxScoreRow[]
       const rows = parseBoxScore(rawGameData);
-
-      // Load into database
       await loader.loadBoxScoreRows(rows);
-
-      // Mark as ingested
       await loader.markIngested({
         game_id: gameId,
         season_year: seasonYear,
@@ -139,27 +172,32 @@ export async function processSeason(
       });
 
       progress.completed++;
-      logger.progress(
-        `[${season}] ${progress.completed + progress.failed}/${gamesToProcess.length} games (${progress.completed} ok, ${progress.failed} err)`,
-      );
+      logProgress();
+    })().catch((err) => {
+      if (signal.aborted) return;
 
-      return rows.length;
-    },
-    config.concurrency,
-    signal,
-    {
-      onError: (game, error) => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      item.attempts++;
+
+      if (item.attempts < MAX_GAME_RETRIES) {
+        logger.warn('Game failed, requeueing', {
+          gameId,
+          attempt: item.attempts,
+          maxRetries: MAX_GAME_RETRIES,
+          error: error.message,
+        });
+        queue.push(item);
+      } else {
         progress.failed++;
-        logger.error('Game ingestion failed', {
-          gameId: game.GameId,
-          season,
+        logger.error('Game exhausted retries', {
+          gameId,
+          attempts: item.attempts,
           error: error.message,
         });
 
-        // Log error to ingestion_log (fire-and-forget)
         loader
           .markIngested({
-            game_id: game.GameId,
+            game_id: gameId,
             season_year: seasonYear,
             season_type: seasonType,
             status: 'error',
@@ -167,18 +205,55 @@ export async function processSeason(
           })
           .catch((logErr) => {
             logger.error('Failed to log ingestion error', {
-              gameId: game.GameId,
+              gameId,
               error: (logErr as Error).message,
             });
           });
-      },
-    },
-  );
+      }
+    }).finally(() => {
+      inFlight.delete(promise);
+    });
+
+    inFlight.add(promise);
+  }
+
+  while (queue.length > 0 || inFlight.size > 0) {
+    if (signal.aborted) {
+      logger.info('Queue aborted, stopping', {
+        processed: progress.completed + progress.failed,
+        remaining: queue.length,
+        inFlight: inFlight.size,
+      });
+      break;
+    }
+
+    // Dispatch next item if under capacity
+    if (queue.length > 0 && inFlight.size < MAX_IN_FLIGHT) {
+      // Wait the adaptive delay before every dispatch
+      await new Promise(resolve => setTimeout(resolve, getCurrentDelay()));
+      if (signal.aborted) break;
+
+      dispatch(queue.shift()!);
+      continue; // Check if we can dispatch more
+    }
+
+    // At capacity or queue drained — wait for one to finish
+    if (inFlight.size > 0) {
+      await Promise.race(inFlight);
+    }
+  }
+
+  // Wait for any stragglers
+  if (inFlight.size > 0) {
+    await Promise.all(inFlight);
+  }
 
   // Clear the progress line
   if (process.stdout.isTTY) {
     process.stdout.write('\n');
   }
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 
   logger.info('Season complete', {
     season,
@@ -187,6 +262,7 @@ export async function processSeason(
     skipped: progress.skipped,
     failed: progress.failed,
     total: progress.totalGames,
+    elapsedSec: elapsed,
   });
 
   return progress;


### PR DESCRIPTION
## Summary
- Replaces fixed-concurrency worker pool with adaptive dispatch queue that self-tunes API request rate based on server responses (#37)
- Dispatch loop fires requests at adaptive intervals with up to 8 in-flight, using `Promise.race` to drain completed work
- Rolling window (last 15 outcomes) drives throttle decisions: speeds up on sustained success, backs off on 503/429, recovers quickly from isolated errors
- Failed games requeue to back of queue (3 queue retries × 6 HTTP retries per attempt)
- New CLI flags: `--delay`, `--min-delay`, `--max-delay` replace `--concurrency`
- Serialized `acquire()` chain prevents concurrent callers from defeating rate limiting

## Files changed (9)
- `scripts/ingest/api/rate-limiter.ts` — full rewrite: adaptive throttle with rolling window
- `scripts/ingest/api/client.ts` — reports success/throttle to rate limiter
- `scripts/ingest/workers/season-worker.ts` — dispatch loop replaces `runPool`
- `scripts/ingest/config.ts` — new delay flags, bounds validation, legacy compat
- `scripts/ingest/types.ts` — `PipelineConfig` uses delay fields
- `scripts/ingest/index.ts` — configures throttle, warns on season-concurrency > 1
- `package.json`, `.github/workflows/*.yml` — updated to `--delay 500`

Closes #37

## Test plan
- [x] Ran full 2024-25 Regular Season ingestion — adaptive rate converged and held steady
- [x] Verify `--force` re-ingests already-completed games
- [x] Verify graceful shutdown (Ctrl+C) drains in-flight and exits cleanly
- [x] Verify `--dry-run` prints plan without writing

🤖 Generated with [Claude Code](https://claude.com/claude-code)