### PR TITLE
Rename ambiguous columns, drop plus_minus, add schema metadata

### DIFF
--- a/app/charts/page.tsx
+++ b/app/charts/page.tsx
@@ -20,7 +20,7 @@ interface ScheduleRow {
   away_team_abbreviation: string;
   home_team_score: number;
   away_team_score: number;
-  status: string;
+  game_status: string;
 }
 
 function AnalyticsContent() {
@@ -152,7 +152,7 @@ function AnalyticsContent() {
                         {game.home_team_abbreviation}
                       </td>
                       <td className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
-                        {game.status}
+                        {game.game_status}
                       </td>
                     </tr>
                   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,7 +55,7 @@ function liveGameToSchedule(game: LiveScoreGame): ScheduleWithBoxScore {
     away_team_abbreviation: game.away_team_abbreviation,
     home_team_score: game.home_team_score,
     away_team_score: game.away_team_score,
-    status: game.status,
+    game_status: game.status,
     created_at: new Date(),
     boxScoreLoaded: true,
     isPlayoff: false,

--- a/app/types.ts
+++ b/app/types.ts
@@ -9,7 +9,7 @@ export interface Game {
   away_team_abbreviation: string;
   home_team_score: number;
   away_team_score: number;
-  status: string;
+  game_status: string;
   homeTeam: Team;
   awayTeam: Team;
   boxScoreLoaded: boolean;

--- a/app/types/schema.ts
+++ b/app/types/schema.ts
@@ -3,7 +3,7 @@
 
 export interface BoxScores {
   game_id: string;
-  team_id: string;
+  team_abbreviation: string;
   entity_id: string;
   player_name: string;
   minutes: string;
@@ -19,7 +19,6 @@ export interface BoxScores {
   fg3_attempted: number;
   ft_made: number;
   ft_attempted: number;
-  plus_minus: number;
   starter: number;
   period: string;
 }
@@ -33,7 +32,7 @@ export interface Schedule {
   away_team_abbreviation: string;
   home_team_score: number;
   away_team_score: number;
-  status: string;
+  game_status: string;
   season_year?: number;
   season_type?: string;
   created_at: Date;
@@ -41,7 +40,7 @@ export interface Schedule {
 
 export interface TeamStats {
   game_id: string;
-  team_id: string;
+  team_abbreviation: string;
   period: string;
   minutes: string;
   points: number;
@@ -56,8 +55,6 @@ export interface TeamStats {
   fg3_attempted: number;
   ft_made: number;
   ft_attempted: number;
-  offensive_possessions: number;
-  defensive_possessions: number;
 }
 
 

--- a/components/BoxScorePanel.tsx
+++ b/components/BoxScorePanel.tsx
@@ -88,7 +88,7 @@ export default function BoxScorePanel({ gameId, onClose, liveData, highlightedCe
 
         const boxScores = [...boxScoresResult.data.toRows()].map(row => ({
           game_id: String(row.game_id),
-          team_id: String(row.team_id),
+          team_abbreviation: String(row.team_abbreviation),
           entity_id: String(row.entity_id),
           player_name: String(row.player_name),
           minutes: String(row.minutes),
@@ -104,14 +104,13 @@ export default function BoxScorePanel({ gameId, onClose, liveData, highlightedCe
           fg3_attempted: Number(row.fg3_attempted),
           ft_made: Number(row.ft_made),
           ft_attempted: Number(row.ft_attempted),
-          plus_minus: Number(row.plus_minus),
           starter: Number(row.starter),
           period: String(row.period)
         })) as BoxScoreType[];
 
         const teamStats = [...teamStatsResult.data.toRows()].map(row => ({
           game_id: String(row.game_id),
-          team_id: String(row.team_id),
+          team_abbreviation: String(row.team_abbreviation),
           period: String(row.period),
           minutes: String(row.minutes),
           points: Number(row.points),
@@ -126,8 +125,6 @@ export default function BoxScorePanel({ gameId, onClose, liveData, highlightedCe
           fg3_attempted: Number(row.fg3_attempted),
           ft_made: Number(row.ft_made),
           ft_attempted: Number(row.ft_attempted),
-          offensive_possessions: Number(row.offensive_possessions),
-          defensive_possessions: Number(row.defensive_possessions)
         })) as TeamStats[];
 
 
@@ -137,11 +134,11 @@ export default function BoxScorePanel({ gameId, onClose, liveData, highlightedCe
         const [gameInfo] = scheduleResult;
         if (!gameInfo) return;
 
-        const homeTeamPlayers = boxScores.filter(player => player.team_id === gameInfo.home_team_abbreviation);
-        const awayTeamPlayers = boxScores.filter(player => player.team_id === gameInfo.away_team_abbreviation);
+        const homeTeamPlayers = boxScores.filter(player => player.team_abbreviation === gameInfo.home_team_abbreviation);
+        const awayTeamPlayers = boxScores.filter(player => player.team_abbreviation === gameInfo.away_team_abbreviation);
 
-        const homeTeamStats = teamStats.find(stat => stat.team_id === gameInfo.home_team_abbreviation && stat.period === 'FullGame');
-        const awayTeamStats = teamStats.find(stat => stat.team_id === gameInfo.away_team_abbreviation && stat.period === 'FullGame');
+        const homeTeamStats = teamStats.find(stat => stat.team_abbreviation === gameInfo.home_team_abbreviation && stat.period === 'FullGame');
+        const awayTeamStats = teamStats.find(stat => stat.team_abbreviation === gameInfo.away_team_abbreviation && stat.period === 'FullGame');
 
         if (!cancelled) {
           setData({
@@ -167,7 +164,7 @@ export default function BoxScorePanel({ gameId, onClose, liveData, highlightedCe
                 threePointersAttempted: player.fg3_attempted,
                 freeThrowsMade: player.ft_made,
                 freeThrowsAttempted: player.ft_attempted,
-                plusMinus: player.plus_minus,
+                plusMinus: 0,
                 starter: player.starter === 1
               })),
               ...homeTeamStats
@@ -193,7 +190,7 @@ export default function BoxScorePanel({ gameId, onClose, liveData, highlightedCe
                 threePointersAttempted: player.fg3_attempted,
                 freeThrowsMade: player.ft_made,
                 freeThrowsAttempted: player.ft_attempted,
-                plusMinus: player.plus_minus,
+                plusMinus: 0,
                 starter: player.starter === 1
               })),
               ...awayTeamStats

--- a/components/PlayerGameLogPanel.tsx
+++ b/components/PlayerGameLogPanel.tsx
@@ -73,7 +73,7 @@ export default function PlayerGameLogPanel({ entityId, playerName, onClose }: Pl
             s.home_team_score,
             s.away_team_score,
             CASE
-              WHEN b.team_id = s.home_team_abbreviation THEN
+              WHEN b.team_abbreviation = s.home_team_abbreviation THEN
                 CASE
                   WHEN s.home_team_score > s.away_team_score THEN 'W'
                   WHEN s.home_team_score < s.away_team_score THEN 'L'
@@ -87,7 +87,7 @@ export default function PlayerGameLogPanel({ entityId, playerName, onClose }: Pl
                 END
             END AS result,
             CASE
-              WHEN b.team_id = s.home_team_abbreviation THEN s.home_team_score - s.away_team_score
+              WHEN b.team_abbreviation = s.home_team_abbreviation THEN s.home_team_score - s.away_team_score
               ELSE s.away_team_score - s.home_team_score
             END AS margin
           FROM ${SOURCE_TABLES.BOX_SCORES} b
@@ -104,7 +104,7 @@ export default function PlayerGameLogPanel({ entityId, playerName, onClose }: Pl
         const gameLog = [...result.data.toRows()].map(row => ({
           game_date: utcToLocalDate(String(row.game_date)),
           game_id: String(row.game_id),
-          team_id: String(row.team_id),
+          team_abbreviation: String(row.team_abbreviation),
           entity_id: String(row.entity_id),
           player_name: String(row.player_name),
           minutes: String(row.minutes),
@@ -120,7 +120,6 @@ export default function PlayerGameLogPanel({ entityId, playerName, onClose }: Pl
           fg3_attempted: Number(row.fg3_attempted),
           ft_made: Number(row.ft_made),
           ft_attempted: Number(row.ft_attempted),
-          plus_minus: Number(row.plus_minus),
           starter: Number(row.starter),
           period: String(row.period),
           home_team_id: String(row.home_team_id),

--- a/components/__tests__/GameCard.test.tsx
+++ b/components/__tests__/GameCard.test.tsx
@@ -13,7 +13,7 @@ const makeGame = (overrides?: Partial<ScheduleWithBoxScore>): ScheduleWithBoxSco
   away_team_abbreviation: 'BOS',
   home_team_score: 110,
   away_team_score: 105,
-  status: 'Final',
+  game_status: 'Final',
   created_at: new Date('2024-11-02T00:00:00Z'),
   ...overrides,
 });

--- a/components/charts/PlayerPerformanceTrend.tsx
+++ b/components/charts/PlayerPerformanceTrend.tsx
@@ -31,7 +31,6 @@ interface GameLogEntry {
   fg3_attempted: number;
   ft_made: number;
   ft_attempted: number;
-  plus_minus: number;
 }
 
 interface PlayerPerformanceTrendProps {
@@ -48,7 +47,6 @@ const STAT_OPTIONS = [
   { key: 'turnovers', label: 'TO', color: '#6b7280' },
   { key: 'fg3_made', label: '3PM', color: '#06b6d4' },
   { key: 'decimal_minutes', label: 'MIN', color: '#f97316' },
-  { key: 'plus_minus', label: '+/-', color: '#ec4899' },
 ] as const;
 
 type StatKey = typeof STAT_OPTIONS[number]['key'];

--- a/hooks/__tests__/useGameData.test.ts
+++ b/hooks/__tests__/useGameData.test.ts
@@ -37,7 +37,7 @@ describe('useSchedule', () => {
         away_team_abbreviation: 'BOS',
         home_team_score: 110,
         away_team_score: 105,
-        status: 'Final',
+        game_status: 'Final',
         created_at: '2024-11-02T00:00:00',
       },
     ];
@@ -49,7 +49,6 @@ describe('useSchedule', () => {
     const { result } = renderHook(() => useSchedule());
     const schedule = await result.current.fetchSchedule();
 
-    expect(mockLoadEssentialTables).toHaveBeenCalledTimes(1);
     expect(mockEvaluateQuery).toHaveBeenCalledTimes(1);
     expect(mockEvaluateQuery.mock.calls[0][0]).toContain('schedule');
 
@@ -80,10 +79,10 @@ describe('useBoxScores', () => {
 
   it('fetchBoxScores groups period scores by game_id', async () => {
     const mockRows = [
-      { game_id: 'G1', team_id: 'LAL', period: '1', points: 25 },
-      { game_id: 'G1', team_id: 'LAL', period: '2', points: 30 },
-      { game_id: 'G1', team_id: 'BOS', period: '1', points: 28 },
-      { game_id: 'G2', team_id: 'GSW', period: '1', points: 32 },
+      { game_id: 'G1', team_abbreviation: 'LAL', period: '1', points: 25 },
+      { game_id: 'G1', team_abbreviation: 'LAL', period: '2', points: 30 },
+      { game_id: 'G1', team_abbreviation: 'BOS', period: '1', points: 28 },
+      { game_id: 'G2', team_abbreviation: 'GSW', period: '1', points: 32 },
     ];
 
     mockEvaluateQuery.mockResolvedValueOnce({
@@ -92,8 +91,6 @@ describe('useBoxScores', () => {
 
     const { result } = renderHook(() => useBoxScores());
     const scores = await result.current.fetchBoxScores();
-
-    expect(mockLoadEssentialTables).toHaveBeenCalledTimes(1);
 
     // G1 should have 3 entries
     expect(scores['G1']).toHaveLength(3);
@@ -119,7 +116,7 @@ describe('useBoxScores', () => {
 
   it('fetchBoxScores converts points to numbers', async () => {
     const mockRows = [
-      { game_id: 'G1', team_id: 'LAL', period: '1', points: '25' },
+      { game_id: 'G1', team_abbreviation: 'LAL', period: '1', points: '25' },
     ];
 
     mockEvaluateQuery.mockResolvedValueOnce({

--- a/hooks/useGameData.ts
+++ b/hooks/useGameData.ts
@@ -60,7 +60,7 @@ export function useSchedule() {
           away_team_abbreviation: game.away_team_abbreviation,
           home_team_score: game.home_team_score,
           away_team_score: game.away_team_score,
-          status: game.status,
+          game_status: game.game_status,
           created_at: game.created_at
         };
       });
@@ -83,18 +83,18 @@ export function useBoxScores() {
       if (filters?.seasonYear || (filters?.seasonType && filters.seasonType !== 'all')) {
         const whereClause = buildSeasonWhereClause(filters, 's');
         query = `
-          SELECT ts.game_id, ts.team_id, ts.period, ts.points
+          SELECT ts.game_id, ts.team_abbreviation, ts.period, ts.points
           FROM ${SOURCE_TABLES.TEAM_STATS} ts
           JOIN ${SOURCE_TABLES.SCHEDULE} s ON ts.game_id = s.game_id
           WHERE ts.period != 'FullGame'${whereClause}
-          ORDER BY ts.game_id, ts.team_id, CAST(ts.period AS INTEGER)
+          ORDER BY ts.game_id, ts.team_abbreviation, CAST(ts.period AS INTEGER)
         `;
       } else {
         query = `
-          SELECT game_id, team_id, period, points
+          SELECT game_id, team_abbreviation, period, points
           FROM ${SOURCE_TABLES.TEAM_STATS}
           WHERE period != 'FullGame'
-          ORDER BY game_id, team_id, CAST(period AS INTEGER)
+          ORDER BY game_id, team_abbreviation, CAST(period AS INTEGER)
         `;
       }
 
@@ -111,7 +111,7 @@ export function useBoxScores() {
       for (const score of periodScores) {
         const scores = gameScores.get(score.game_id)!;
         scores.push({
-          teamId: score.team_id,
+          teamId: score.team_abbreviation,
           period: score.period,
           points: Number(score.points)
         });

--- a/lib/generated/sql-utils.ts
+++ b/lib/generated/sql-utils.ts
@@ -4,7 +4,7 @@
 
 export const box_scoresColumns = [
   "game_id",
-  "team_id",
+  "team_abbreviation",
   "entity_id",
   "player_name",
   "minutes",
@@ -20,7 +20,6 @@ export const box_scoresColumns = [
   "fg3_attempted",
   "ft_made",
   "ft_attempted",
-  "plus_minus",
   "starter",
   "period"
 ] as const;
@@ -35,14 +34,14 @@ export const scheduleColumns = [
   "away_team_abbreviation",
   "home_team_score",
   "away_team_score",
-  "status",
+  "game_status",
   "created_at"
 ] as const;
 export type ScheduleColumn = typeof scheduleColumns[number];
 
 export const team_statsColumns = [
   "game_id",
-  "team_id",
+  "team_abbreviation",
   "period",
   "minutes",
   "points",
@@ -56,9 +55,7 @@ export const team_statsColumns = [
   "fg3_made",
   "fg3_attempted",
   "ft_made",
-  "ft_attempted",
-  "offensive_possessions",
-  "defensive_possessions"
+  "ft_attempted"
 ] as const;
 export type TeamStatsColumn = typeof team_statsColumns[number];
 
@@ -69,9 +66,9 @@ export function generateSelectQuery(
 ): string {
   const columnsStr = columns.join(',\n        ');
   const baseQuery = `
-      SELECT 
+      SELECT
         ${columnsStr}
       FROM ${tableName}`;
-  
+
   return whereClause ? `${baseQuery}\n      ${whereClause}` : baseQuery;
 }

--- a/scripts/data-quality/auto-resolve.ts
+++ b/scripts/data-quality/auto-resolve.ts
@@ -10,24 +10,24 @@ export interface AutoResolveResult {
 export async function autoResolve(db: MotherDuckConnection): Promise<AutoResolveResult> {
   const before = await db.query<{ cnt: number }>(
     `SELECT COUNT(*) AS cnt FROM main.data_quality_quarantine
-     WHERE detection_type = 'team_switch' AND status = 'pending'`,
+     WHERE detection_type = 'team_switch' AND resolution_status = 'pending'`,
   );
   const pendingBefore = before[0]?.cnt ?? 0;
 
   await db.execute(`
     UPDATE main.data_quality_quarantine
-    SET status = 'approved',
+    SET resolution_status = 'approved',
         resolved_at = CURRENT_TIMESTAMP,
         resolved_by = 'auto-resolve:3-game-rule'
     WHERE detection_type = 'team_switch'
-      AND status = 'pending'
+      AND resolution_status = 'pending'
       AND (entity_id, actual_team) IN (
         SELECT entity_id, actual_team FROM (
           SELECT dqq.entity_id, dqq.actual_team, COUNT(DISTINCT bs.game_id) AS cnt
           FROM main.data_quality_quarantine dqq
           JOIN main.box_scores bs
-            ON dqq.entity_id = bs.entity_id AND bs.team_id = dqq.actual_team
-          WHERE dqq.status = 'pending'
+            ON dqq.entity_id = bs.entity_id AND bs.team_abbreviation = dqq.actual_team
+          WHERE dqq.resolution_status = 'pending'
             AND dqq.detection_type = 'team_switch'
             AND bs.period = 'FullGame'
           GROUP BY dqq.entity_id, dqq.actual_team
@@ -37,7 +37,7 @@ export async function autoResolve(db: MotherDuckConnection): Promise<AutoResolve
 
   const after = await db.query<{ cnt: number }>(
     `SELECT COUNT(*) AS cnt FROM main.data_quality_quarantine
-     WHERE detection_type = 'team_switch' AND status = 'pending'`,
+     WHERE detection_type = 'team_switch' AND resolution_status = 'pending'`,
   );
   const pendingAfter = after[0]?.cnt ?? 0;
 

--- a/scripts/data-quality/check.ts
+++ b/scripts/data-quality/check.ts
@@ -100,10 +100,10 @@ async function main(): Promise<void> {
 
     // Final quarantine status
     const pending = await db.query<{ cnt: number }>(
-      `SELECT COUNT(*) AS cnt FROM main.data_quality_quarantine WHERE status = 'pending'`,
+      `SELECT COUNT(*) AS cnt FROM main.data_quality_quarantine WHERE resolution_status = 'pending'`,
     );
     const approved = await db.query<{ cnt: number }>(
-      `SELECT COUNT(*) AS cnt FROM main.data_quality_quarantine WHERE status = 'approved'`,
+      `SELECT COUNT(*) AS cnt FROM main.data_quality_quarantine WHERE resolution_status = 'approved'`,
     );
     console.log(`\nQuarantine status: ${pending[0]?.cnt ?? 0} pending, ${approved[0]?.cnt ?? 0} approved\n`);
   } finally {

--- a/scripts/data-quality/detectors/duplicates.ts
+++ b/scripts/data-quality/detectors/duplicates.ts
@@ -19,15 +19,15 @@ export const duplicatesDetector: Detector = {
         d.entity_id,
         d.player_name,
         NULL AS expected_team,
-        d.team_id AS actual_team,
+        d.team_abbreviation AS actual_team,
         '${DETECTION_TYPE}' AS detection_type,
         'Duplicate count: ' || d.cnt || ' for period ' || d.period AS details
       FROM (
         SELECT
-          game_id, entity_id, period, team_id, player_name,
+          game_id, entity_id, period, team_abbreviation, player_name,
           COUNT(*) AS cnt
         FROM main.box_scores
-        GROUP BY game_id, entity_id, period, team_id, player_name
+        GROUP BY game_id, entity_id, period, team_abbreviation, player_name
         HAVING COUNT(*) > 1
       ) d
       WHERE NOT EXISTS (

--- a/scripts/data-quality/detectors/impossible-stats.ts
+++ b/scripts/data-quality/detectors/impossible-stats.ts
@@ -19,7 +19,7 @@ export const impossibleStatsDetector: Detector = {
         bs.entity_id,
         bs.player_name,
         NULL AS expected_team,
-        bs.team_id AS actual_team,
+        bs.team_abbreviation AS actual_team,
         '${DETECTION_TYPE}' AS detection_type,
         CASE
           WHEN bs.points > 82 THEN 'Points: ' || bs.points

--- a/scripts/data-quality/detectors/score-mismatch.ts
+++ b/scripts/data-quality/detectors/score-mismatch.ts
@@ -18,31 +18,31 @@ export const scoreMismatchDetector: Detector = {
         (game_id, entity_id, player_name, expected_team, actual_team, detection_type, details)
       SELECT
         m.game_id,
-        m.team_id AS entity_id,
+        m.team_abbreviation AS entity_id,
         'TEAM' AS player_name,
         NULL AS expected_team,
-        m.team_id AS actual_team,
+        m.team_abbreviation AS actual_team,
         '${DETECTION_TYPE}' AS detection_type,
         'Player sum: ' || m.player_sum || ', Schedule score: ' || m.schedule_score AS details
       FROM (
         SELECT
           bs.game_id,
-          bs.team_id,
+          bs.team_abbreviation,
           SUM(bs.points) AS player_sum,
           CASE
-            WHEN bs.team_id = CAST(s.home_team_id AS VARCHAR) THEN s.home_team_score
+            WHEN bs.team_abbreviation = s.home_team_abbreviation THEN s.home_team_score
             ELSE s.away_team_score
           END AS schedule_score
         FROM main.box_scores bs
         JOIN main.schedule s ON bs.game_id = s.game_id
         WHERE bs.period = 'FullGame'
-        GROUP BY bs.game_id, bs.team_id, s.home_team_id, s.away_team_id, s.home_team_score, s.away_team_score
+        GROUP BY bs.game_id, bs.team_abbreviation, s.home_team_abbreviation, s.away_team_abbreviation, s.home_team_score, s.away_team_score
       ) m
       WHERE m.player_sum != m.schedule_score
         AND NOT EXISTS (
           SELECT 1 FROM main.data_quality_quarantine dqq
           WHERE dqq.game_id = m.game_id
-            AND dqq.entity_id = m.team_id
+            AND dqq.entity_id = m.team_abbreviation
             AND dqq.detection_type = '${DETECTION_TYPE}'
         )
     `;

--- a/scripts/data-quality/detectors/team-switch.ts
+++ b/scripts/data-quality/detectors/team-switch.ts
@@ -1,4 +1,4 @@
-// Detect players whose team_id changed from their most recent prior game.
+// Detect players whose team_abbreviation changed from their most recent prior game.
 // Idempotent: skips records already in quarantine.
 
 import type { MotherDuckConnection } from '../../ingest/db/connection';
@@ -19,13 +19,13 @@ export const teamSwitchDetector: Detector = {
         curr.game_id,
         curr.entity_id,
         curr.player_name,
-        prev.team_id AS expected_team,
-        curr.team_id AS actual_team,
+        prev.team_abbreviation AS expected_team,
+        curr.team_abbreviation AS actual_team,
         '${DETECTION_TYPE}' AS detection_type,
-        'Team changed from ' || prev.team_id || ' to ' || curr.team_id AS details
+        'Team changed from ' || prev.team_abbreviation || ' to ' || curr.team_abbreviation AS details
       FROM (
         SELECT
-          bs.game_id, bs.entity_id, bs.player_name, bs.team_id,
+          bs.game_id, bs.entity_id, bs.player_name, bs.team_abbreviation,
           s.game_date,
           ROW_NUMBER() OVER (PARTITION BY bs.entity_id ORDER BY s.game_date DESC, bs.game_id DESC) AS rn
         FROM main.box_scores bs
@@ -34,14 +34,14 @@ export const teamSwitchDetector: Detector = {
       ) curr
       JOIN (
         SELECT
-          bs.entity_id, bs.team_id,
+          bs.entity_id, bs.team_abbreviation,
           s.game_date,
           ROW_NUMBER() OVER (PARTITION BY bs.entity_id ORDER BY s.game_date DESC, bs.game_id DESC) AS rn
         FROM main.box_scores bs
         JOIN main.schedule s ON bs.game_id = s.game_id
         WHERE bs.period = 'FullGame'
       ) prev ON curr.entity_id = prev.entity_id AND prev.rn = curr.rn + 1
-      WHERE curr.team_id != prev.team_id
+      WHERE curr.team_abbreviation != prev.team_abbreviation
         AND NOT EXISTS (
           SELECT 1 FROM main.data_quality_quarantine dqq
           WHERE dqq.game_id = curr.game_id

--- a/scripts/data-quality/github-issues.ts
+++ b/scripts/data-quality/github-issues.ts
@@ -150,7 +150,7 @@ export async function createIssuesForPending(db: MotherDuckConnection): Promise<
       CAST(s.game_date AS VARCHAR) AS game_date
     FROM main.data_quality_quarantine dqq
     LEFT JOIN main.schedule s ON dqq.game_id = s.game_id
-    WHERE dqq.status = 'pending'
+    WHERE dqq.resolution_status = 'pending'
       AND dqq.github_issue_number IS NULL
     ORDER BY dqq.created_at ASC
   `);

--- a/scripts/ingest/db/loader.ts
+++ b/scripts/ingest/db/loader.ts
@@ -45,23 +45,23 @@ export class Loader {
       const values = batch
         .map(
           (r) =>
-            `(${esc(r.game_id)}, ${esc(r.team_id)}, ${esc(r.entity_id)}, ${esc(r.player_name)}, ` +
+            `(${esc(r.game_id)}, ${esc(r.team_abbreviation)}, ${esc(r.entity_id)}, ${esc(r.player_name)}, ` +
             `${esc(r.period)}, ${esc(r.minutes)}, ` +
             `${num(r.points)}, ${num(r.rebounds)}, ${num(r.assists)}, ` +
             `${num(r.steals)}, ${num(r.blocks)}, ${num(r.turnovers)}, ` +
             `${num(r.fg_made)}, ${num(r.fg_attempted)}, ` +
             `${num(r.fg3_made)}, ${num(r.fg3_attempted)}, ` +
             `${num(r.ft_made)}, ${num(r.ft_attempted)}, ` +
-            `${num(r.plus_minus)}, ${num(r.starter)})`,
+            `${num(r.starter)})`,
         )
         .join(',\n');
 
       await this.db.execute(
         `INSERT OR REPLACE INTO main.box_scores (
-          game_id, team_id, entity_id, player_name, period, minutes,
+          game_id, team_abbreviation, entity_id, player_name, period, minutes,
           points, rebounds, assists, steals, blocks, turnovers,
           fg_made, fg_attempted, fg3_made, fg3_attempted,
-          ft_made, ft_attempted, plus_minus, starter
+          ft_made, ft_attempted, starter
         ) VALUES\n${values}`,
       );
 
@@ -86,7 +86,7 @@ export class Loader {
             `${num(r.home_team_id)}, ${num(r.away_team_id)}, ` +
             `${esc(r.home_team_abbreviation)}, ${esc(r.away_team_abbreviation)}, ` +
             `${num(r.home_team_score)}, ${num(r.away_team_score)}, ` +
-            `${esc(r.status)}, ${num(r.season_year)}, ${esc(r.season_type)})`,
+            `${esc(r.game_status)}, ${num(r.season_year)}, ${esc(r.season_type)})`,
         )
         .join(',\n');
 
@@ -96,7 +96,7 @@ export class Loader {
           home_team_id, away_team_id,
           home_team_abbreviation, away_team_abbreviation,
           home_team_score, away_team_score,
-          status, season_year, season_type
+          game_status, season_year, season_type
         ) VALUES\n${values}`,
       );
 
@@ -112,12 +112,12 @@ export class Loader {
   async markIngested(entry: IngestionLogEntry): Promise<void> {
     await this.db.execute(
       `INSERT OR REPLACE INTO main.ingestion_log (
-        game_id, season_year, season_type, status, error_message
+        game_id, season_year, season_type, ingestion_status, error_message
       ) VALUES (
         ${esc(entry.game_id)},
         ${num(entry.season_year)},
         ${esc(entry.season_type)},
-        ${esc(entry.status)},
+        ${esc(entry.ingestion_status)},
         ${esc(entry.error_message ?? null)}
       )`,
     );
@@ -127,7 +127,7 @@ export class Loader {
   async isGameIngested(gameId: string): Promise<boolean> {
     const rows = await this.db.query<{ cnt: number }>(
       `SELECT COUNT(*) AS cnt FROM main.ingestion_log
-       WHERE game_id = ${esc(gameId)} AND status = 'success'`,
+       WHERE game_id = ${esc(gameId)} AND ingestion_status = 'success'`,
     );
     return (rows[0]?.cnt ?? 0) > 0;
   }
@@ -138,7 +138,7 @@ export class Loader {
       `SELECT game_id FROM main.ingestion_log
        WHERE season_year = ${num(seasonYear)}
          AND season_type = ${esc(seasonType)}
-         AND status = 'success'`,
+         AND ingestion_status = 'success'`,
     );
     return new Set(rows.map((r) => r.game_id));
   }

--- a/scripts/ingest/db/queries.ts
+++ b/scripts/ingest/db/queries.ts
@@ -37,8 +37,8 @@ export async function getIngestionSummary(
       season_year,
       season_type,
       COUNT(*) AS total_games,
-      COUNT(*) FILTER (WHERE status = 'success') AS success_count,
-      COUNT(*) FILTER (WHERE status = 'error') AS error_count,
+      COUNT(*) FILTER (WHERE ingestion_status = 'success') AS success_count,
+      COUNT(*) FILTER (WHERE ingestion_status = 'error') AS error_count,
       MAX(ingested_at) AS last_ingested_at
     FROM ingestion_log
     ${where}
@@ -60,7 +60,7 @@ export async function getRecentErrors(
       ingested_at,
       error_message
     FROM ingestion_log
-    WHERE status = 'error'
+    WHERE ingestion_status = 'error'
     ORDER BY ingested_at DESC
     LIMIT ${limit}
   `);
@@ -72,7 +72,7 @@ export async function getOverallStats(
 ): Promise<OverallStats> {
   const rows = await db.query<OverallStats>(`
     SELECT
-      (SELECT COUNT(*) FROM ingestion_log WHERE status = 'success') AS total_games_ingested,
+      (SELECT COUNT(*) FROM ingestion_log WHERE ingestion_status = 'success') AS total_games_ingested,
       (SELECT COUNT(*) FROM box_scores WHERE period = 'FullGame') AS total_box_score_rows,
       (SELECT COUNT(DISTINCT entity_id) FROM box_scores WHERE period = 'FullGame') AS total_unique_players
   `);

--- a/scripts/ingest/db/schema.ts
+++ b/scripts/ingest/db/schema.ts
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS main.schedule (
   away_team_abbreviation TEXT NOT NULL,
   home_team_score INTEGER NOT NULL,
   away_team_score INTEGER NOT NULL,
-  status TEXT NOT NULL,
+  game_status TEXT NOT NULL,
   season_year INTEGER,
   season_type TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS main.schedule (
 export const CREATE_BOX_SCORES = `
 CREATE TABLE IF NOT EXISTS main.box_scores (
   game_id VARCHAR,
-  team_id VARCHAR,
+  team_abbreviation VARCHAR,
   entity_id VARCHAR,
   player_name VARCHAR,
   period VARCHAR NOT NULL DEFAULT 'FullGame',
@@ -37,7 +37,6 @@ CREATE TABLE IF NOT EXISTS main.box_scores (
   fg3_attempted INTEGER NOT NULL DEFAULT 0,
   ft_made INTEGER NOT NULL DEFAULT 0,
   ft_attempted INTEGER NOT NULL DEFAULT 0,
-  plus_minus INTEGER,
   starter INTEGER,
   PRIMARY KEY (game_id, entity_id, period)
 );`;
@@ -48,7 +47,7 @@ CREATE TABLE IF NOT EXISTS main.ingestion_log (
   season_year INTEGER NOT NULL,
   season_type TEXT NOT NULL,
   ingested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  status TEXT NOT NULL DEFAULT 'success',
+  ingestion_status TEXT NOT NULL DEFAULT 'success',
   error_message TEXT
 );`;
 
@@ -60,7 +59,7 @@ CREATE TABLE IF NOT EXISTS main.data_quality_quarantine (
   expected_team VARCHAR,
   actual_team VARCHAR NOT NULL,
   detection_type VARCHAR NOT NULL DEFAULT 'team_switch',
-  status VARCHAR NOT NULL DEFAULT 'pending',
+  resolution_status VARCHAR NOT NULL DEFAULT 'pending',
   details TEXT,
   github_issue_number INTEGER,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -74,47 +73,80 @@ CREATE OR REPLACE VIEW main.team_stats AS
 WITH period_scores AS (
   SELECT
     game_id,
-    team_id,
+    team_abbreviation,
     period,
     '12:00' as minutes,
-    SUM(points) as points,
-    SUM(rebounds) as rebounds,
-    SUM(assists) as assists,
-    SUM(steals) as steals,
-    SUM(blocks) as blocks,
-    SUM(turnovers) as turnovers,
-    SUM(fg_made) as fg_made,
-    SUM(fg_attempted) as fg_attempted,
-    SUM(fg3_made) as fg3_made,
-    SUM(fg3_attempted) as fg3_attempted,
-    SUM(ft_made) as ft_made,
-    SUM(ft_attempted) as ft_attempted
+    CAST(SUM(points) AS INTEGER) as points,
+    CAST(SUM(rebounds) AS INTEGER) as rebounds,
+    CAST(SUM(assists) AS INTEGER) as assists,
+    CAST(SUM(steals) AS INTEGER) as steals,
+    CAST(SUM(blocks) AS INTEGER) as blocks,
+    CAST(SUM(turnovers) AS INTEGER) as turnovers,
+    CAST(SUM(fg_made) AS INTEGER) as fg_made,
+    CAST(SUM(fg_attempted) AS INTEGER) as fg_attempted,
+    CAST(SUM(fg3_made) AS INTEGER) as fg3_made,
+    CAST(SUM(fg3_attempted) AS INTEGER) as fg3_attempted,
+    CAST(SUM(ft_made) AS INTEGER) as ft_made,
+    CAST(SUM(ft_attempted) AS INTEGER) as ft_attempted
   FROM nba_box_scores_v2.main.box_scores
   WHERE period != 'FullGame'
-  GROUP BY game_id, team_id, period
+  GROUP BY game_id, team_abbreviation, period
 )
 SELECT * FROM period_scores
 UNION ALL
 SELECT
   game_id,
-  team_id,
+  team_abbreviation,
   'FullGame' as period,
   NULL as minutes,
-  SUM(points) as points,
-  SUM(rebounds) as rebounds,
-  SUM(assists) as assists,
-  SUM(steals) as steals,
-  SUM(blocks) as blocks,
-  SUM(turnovers) as turnovers,
-  SUM(fg_made) as fg_made,
-  SUM(fg_attempted) as fg_attempted,
-  SUM(fg3_made) as fg3_made,
-  SUM(fg3_attempted) as fg3_attempted,
-  SUM(ft_made) as ft_made,
-  SUM(ft_attempted) as ft_attempted
+  CAST(SUM(points) AS INTEGER) as points,
+  CAST(SUM(rebounds) AS INTEGER) as rebounds,
+  CAST(SUM(assists) AS INTEGER) as assists,
+  CAST(SUM(steals) AS INTEGER) as steals,
+  CAST(SUM(blocks) AS INTEGER) as blocks,
+  CAST(SUM(turnovers) AS INTEGER) as turnovers,
+  CAST(SUM(fg_made) AS INTEGER) as fg_made,
+  CAST(SUM(fg_attempted) AS INTEGER) as fg_attempted,
+  CAST(SUM(fg3_made) AS INTEGER) as fg3_made,
+  CAST(SUM(fg3_attempted) AS INTEGER) as fg3_attempted,
+  CAST(SUM(ft_made) AS INTEGER) as ft_made,
+  CAST(SUM(ft_attempted) AS INTEGER) as ft_attempted
 FROM period_scores
 WHERE period <> 'FullGame'
-GROUP BY game_id, team_id;`;
+GROUP BY game_id, team_abbreviation;`;
+
+export const CREATE_PLAYERS_VIEW = `
+CREATE OR REPLACE VIEW main.players AS
+SELECT DISTINCT entity_id, player_name
+FROM nba_box_scores_v2.main.box_scores
+WHERE period = 'FullGame';`;
+
+export const SCHEMA_COMMENTS = `
+COMMENT ON TABLE main.schedule IS 'Game schedule with one row per NBA game. Grain: game_id.';
+COMMENT ON COLUMN main.schedule.game_id IS 'Unique NBA game identifier (e.g., 0022400061).';
+COMMENT ON COLUMN main.schedule.game_status IS 'Game completion status (e.g., Final). Renamed from status to avoid ambiguity.';
+COMMENT ON COLUMN main.schedule.home_team_abbreviation IS 'Three-letter team code (e.g., BOS). Joins to box_scores.team_abbreviation.';
+COMMENT ON COLUMN main.schedule.away_team_abbreviation IS 'Three-letter team code (e.g., NYK). Joins to box_scores.team_abbreviation.';
+
+COMMENT ON TABLE main.box_scores IS 'Per-player per-period box score stats. Grain: (game_id, entity_id, period).';
+COMMENT ON COLUMN main.box_scores.game_id IS 'Foreign key to schedule.game_id.';
+COMMENT ON COLUMN main.box_scores.entity_id IS 'Unique player identifier from NBA API.';
+COMMENT ON COLUMN main.box_scores.team_abbreviation IS 'Three-letter team code. Joins to schedule.home_team_abbreviation or schedule.away_team_abbreviation.';
+COMMENT ON COLUMN main.box_scores.period IS 'Game period: 1-4 for quarters, 5+ for OT, FullGame for aggregated totals.';
+COMMENT ON COLUMN main.box_scores.minutes IS 'Playing time in MM:SS format.';
+COMMENT ON COLUMN main.box_scores.starter IS 'Starter flag: 1=starter, 0=bench. Only set on FullGame rows; NULL for per-period rows.';
+
+COMMENT ON TABLE main.ingestion_log IS 'Tracks which games have been ingested and their outcome. Grain: game_id.';
+COMMENT ON COLUMN main.ingestion_log.ingestion_status IS 'Outcome of the ingestion attempt: success or error. Renamed from status to avoid ambiguity.';
+
+COMMENT ON TABLE main.data_quality_quarantine IS 'Detected data anomalies pending review. Grain: (game_id, entity_id, detection_type).';
+COMMENT ON COLUMN main.data_quality_quarantine.resolution_status IS 'Review status: pending, approved, or rejected. Renamed from status to avoid ambiguity.';
+
+COMMENT ON VIEW main.team_stats IS 'Aggregated team stats per game per period. Derived from box_scores via SUM.';
+COMMENT ON COLUMN main.team_stats.team_abbreviation IS 'Three-letter team code. Joins to schedule.home_team_abbreviation or schedule.away_team_abbreviation.';
+
+COMMENT ON VIEW main.players IS 'Distinct player dimension derived from FullGame box_scores rows.';
+`;
 
 export const ALL_DDL = [
   CREATE_SCHEDULE,
@@ -122,4 +154,6 @@ export const ALL_DDL = [
   CREATE_INGESTION_LOG,
   CREATE_DATA_QUALITY_QUARANTINE,
   CREATE_TEAM_STATS_VIEW,
+  CREATE_PLAYERS_VIEW,
+  SCHEMA_COMMENTS,
 ] as const;

--- a/scripts/ingest/parse/__tests__/box-score-parser.test.ts
+++ b/scripts/ingest/parse/__tests__/box-score-parser.test.ts
@@ -21,7 +21,7 @@ describe('parseBoxScore', () => {
   it('returns BoxScoreRow objects with all required fields', () => {
     const first = rows[0];
     expect(first).toHaveProperty('game_id');
-    expect(first).toHaveProperty('team_id');
+    expect(first).toHaveProperty('team_abbreviation');
     expect(first).toHaveProperty('entity_id');
     expect(first).toHaveProperty('player_name');
     expect(first).toHaveProperty('period');
@@ -38,7 +38,6 @@ describe('parseBoxScore', () => {
     expect(first).toHaveProperty('fg3_attempted');
     expect(first).toHaveProperty('ft_made');
     expect(first).toHaveProperty('ft_attempted');
-    expect(first).toHaveProperty('plus_minus');
     expect(first).toHaveProperty('starter');
   });
 
@@ -52,7 +51,7 @@ describe('parseBoxScore', () => {
   });
 
   it('produces rows for both teams', () => {
-    const teams = new Set(rows.map(r => r.team_id));
+    const teams = new Set(rows.map(r => r.team_abbreviation));
     expect(teams.has('NYK')).toBe(true);
     expect(teams.has('BOS')).toBe(true);
     expect(teams.size).toBe(2);
@@ -110,7 +109,7 @@ describe('parseBoxScore', () => {
   it('assigns starters: exactly 5 per team in FullGame rows', () => {
     const fullGameRows = rows.filter(r => r.period === 'FullGame');
     for (const team of ['NYK', 'BOS']) {
-      const teamFG = fullGameRows.filter(r => r.team_id === team);
+      const teamFG = fullGameRows.filter(r => r.team_abbreviation === team);
       const starters = teamFG.filter(r => r.starter === 1);
       const bench = teamFG.filter(r => r.starter === 0);
       expect(starters).toHaveLength(5);

--- a/scripts/ingest/parse/box-score-parser.ts
+++ b/scripts/ingest/parse/box-score-parser.ts
@@ -96,7 +96,7 @@ function parsePlayerPeriod(
 
   return {
     game_id: gameId,
-    team_id: teamAbbr,
+    team_abbreviation: teamAbbr,
     entity_id: raw.EntityId,
     player_name: raw.Name,
     period,
@@ -113,7 +113,6 @@ function parsePlayerPeriod(
     fg3_attempted: num(raw.FG3A),
     ft_made: num(raw.FtPoints),
     ft_attempted: num(raw.FTA),
-    plus_minus: null, // not available in the raw data per-period
     starter: null, // assigned later via heuristic
   };
 }
@@ -126,11 +125,11 @@ function parsePlayerPeriod(
 function assignStarters(fullGameRows: BoxScoreRow[]): void {
   const byTeam = new Map<string, BoxScoreRow[]>();
   for (const row of fullGameRows) {
-    const list = byTeam.get(row.team_id);
+    const list = byTeam.get(row.team_abbreviation);
     if (list) {
       list.push(row);
     } else {
-      byTeam.set(row.team_id, [row]);
+      byTeam.set(row.team_abbreviation, [row]);
     }
   }
 
@@ -185,7 +184,7 @@ export function parseBoxScore(data: unknown): BoxScoreRow[] {
   // Compute FullGame rows by aggregating per-period data for each player
   const playerMap = new Map<string, BoxScoreRow[]>();
   for (const row of periodRows) {
-    const key = `${row.team_id}:${row.entity_id}`;
+    const key = `${row.team_abbreviation}:${row.entity_id}`;
     const list = playerMap.get(key);
     if (list) {
       list.push(row);
@@ -199,7 +198,7 @@ export function parseBoxScore(data: unknown): BoxScoreRow[] {
     const first = periods[0];
     const fullGame: BoxScoreRow = {
       game_id: first.game_id,
-      team_id: first.team_id,
+      team_abbreviation: first.team_abbreviation,
       entity_id: first.entity_id,
       player_name: first.player_name,
       period: 'FullGame',
@@ -216,7 +215,6 @@ export function parseBoxScore(data: unknown): BoxScoreRow[] {
       fg3_attempted: periods.reduce((s, p) => s + p.fg3_attempted, 0),
       ft_made: periods.reduce((s, p) => s + p.ft_made, 0),
       ft_attempted: periods.reduce((s, p) => s + p.ft_attempted, 0),
-      plus_minus: null,
       starter: null,
     };
     fullGameRows.push(fullGame);

--- a/scripts/ingest/types.ts
+++ b/scripts/ingest/types.ts
@@ -58,7 +58,7 @@ export interface PBPStatsGamesResponse {
 /** Flat row matching the v2 box_scores table schema */
 export interface BoxScoreRow {
   game_id: string;
-  team_id: string;
+  team_abbreviation: string;
   entity_id: string;
   player_name: string;
   period: string;
@@ -75,7 +75,6 @@ export interface BoxScoreRow {
   fg3_attempted: number;
   ft_made: number;
   ft_attempted: number;
-  plus_minus: number | null;
   starter: number | null;
 }
 
@@ -89,7 +88,7 @@ export interface ScheduleRow {
   away_team_abbreviation: string;
   home_team_score: number;
   away_team_score: number;
-  status: string;
+  game_status: string;
   season_year: number;
   season_type: string;
 }
@@ -99,7 +98,7 @@ export interface IngestionLogEntry {
   game_id: string;
   season_year: number;
   season_type: string;
-  status: 'success' | 'error';
+  ingestion_status: 'success' | 'error';
   error_message?: string;
 }
 

--- a/scripts/ingest/workers/season-worker.ts
+++ b/scripts/ingest/workers/season-worker.ts
@@ -109,7 +109,7 @@ export async function processSeason(
     away_team_abbreviation: g.AwayTeamAbbreviation,
     home_team_score: g.HomePoints ?? 0,
     away_team_score: g.AwayPoints ?? 0,
-    status: 'Final',
+    game_status: 'Final',
     season_year: seasonYear,
     season_type: seasonType,
   }));
@@ -168,7 +168,7 @@ export async function processSeason(
         game_id: gameId,
         season_year: seasonYear,
         season_type: seasonType,
-        status: 'success',
+        ingestion_status: 'success',
       });
 
       progress.completed++;
@@ -200,7 +200,7 @@ export async function processSeason(
             game_id: gameId,
             season_year: seasonYear,
             season_type: seasonType,
-            status: 'error',
+            ingestion_status: 'error',
             error_message: error.message,
           })
           .catch((logErr) => {


### PR DESCRIPTION
## Summary
- Rename `box_scores.team_id` → `team_abbreviation` to eliminate naming collision with schedule's numeric `home_team_id`/`away_team_id`
- Rename overloaded `status` columns: `schedule.game_status`, `ingestion_log.ingestion_status`, `quarantine.resolution_status`
- Drop `box_scores.plus_minus` (never populated from API)
- Fix HUGEINT type mismatch by wrapping `SUM()` with `CAST(... AS INTEGER)` in `team_stats` view
- Add `players` view (distinct player dimension from FullGame rows)
- Add `COMMENT ON` statements for all tables, views, and key columns documenting grain, join paths, and field semantics
- Remove `offensive_possessions`/`defensive_possessions` from `TeamStats` (not in view)
- Fix pre-existing stale assertions in `useGameData` tests

## Test plan
- [x] `npm run build` passes with zero type errors
- [x] All 30 relevant tests pass (parser, hooks, GameCard)
- [x] 4 pre-existing `dataLoader` test failures unchanged
- [x] Apply DDL to MotherDuck v2 (ALTER TABLE renames, recreate views) — verified all 327k rows intact
- [ ] Run `npm run data-quality:check` after data load to verify detectors
- [ ] Smoke test dev environment

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)