### PR TITLE
Replace static schema comments with dynamic metadata-generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "ingest:playoffs": "tsx scripts/ingest/index.ts --all --season-type Playoffs",
     "ingest:status": "tsx scripts/ingest/status.ts",
     "data-quality:check": "tsx scripts/data-quality/check.ts",
-    "data-quality:issues": "tsx scripts/data-quality/github-issues.ts"
+    "data-quality:issues": "tsx scripts/data-quality/github-issues.ts",
+    "metadata:refresh": "cd ~/code/metadata_generator && uv run metadata-generator --database nba_box_scores_v2 comments main -x --refresh"
   },
   "dependencies": {
     "@duckdb/node-api": "^1.4.4-r.2",

--- a/scripts/ingest/db/metadata.ts
+++ b/scripts/ingest/db/metadata.ts
@@ -1,0 +1,40 @@
+// Runs metadata-generator to apply dynamic COMMENT ON statements after ingest.
+// Requires `uv` and `metadata-generator` installed at ~/code/metadata_generator.
+
+import { execFile } from 'node:child_process';
+import { resolve } from 'node:path';
+import { logger } from '../util/logger';
+
+const METADATA_GENERATOR_DIR = resolve(process.env.HOME || '~', 'code/metadata_generator');
+
+export async function refreshMetadata(database: string): Promise<void> {
+  logger.info('Refreshing dynamic metadata comments...');
+
+  try {
+    const output = await runCommand('uv', [
+      'run', 'metadata-generator',
+      '--database', database,
+      'comments', 'main',
+      '-x', '--refresh',
+    ], METADATA_GENERATOR_DIR);
+
+    logger.info('Metadata comments applied', { output: output.trim().split('\n').pop() });
+  } catch (error) {
+    // Non-fatal — metadata is nice-to-have, don't fail the pipeline
+    logger.warn('Metadata refresh failed (non-fatal)', {
+      error: (error as Error).message,
+    });
+  }
+}
+
+function runCommand(cmd: string, args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, { cwd, timeout: 120_000 }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`${cmd} failed: ${stderr || error.message}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}

--- a/scripts/ingest/db/schema.ts
+++ b/scripts/ingest/db/schema.ts
@@ -121,32 +121,8 @@ SELECT DISTINCT entity_id, player_name
 FROM nba_box_scores_v2.main.box_scores
 WHERE period = 'FullGame';`;
 
-export const SCHEMA_COMMENTS = `
-COMMENT ON TABLE main.schedule IS 'Game schedule with one row per NBA game. Grain: game_id.';
-COMMENT ON COLUMN main.schedule.game_id IS 'Unique NBA game identifier (e.g., 0022400061).';
-COMMENT ON COLUMN main.schedule.game_status IS 'Game completion status (e.g., Final). Renamed from status to avoid ambiguity.';
-COMMENT ON COLUMN main.schedule.home_team_abbreviation IS 'Three-letter team code (e.g., BOS). Joins to box_scores.team_abbreviation.';
-COMMENT ON COLUMN main.schedule.away_team_abbreviation IS 'Three-letter team code (e.g., NYK). Joins to box_scores.team_abbreviation.';
-
-COMMENT ON TABLE main.box_scores IS 'Per-player per-period box score stats. Grain: (game_id, entity_id, period).';
-COMMENT ON COLUMN main.box_scores.game_id IS 'Foreign key to schedule.game_id.';
-COMMENT ON COLUMN main.box_scores.entity_id IS 'Unique player identifier from NBA API.';
-COMMENT ON COLUMN main.box_scores.team_abbreviation IS 'Three-letter team code. Joins to schedule.home_team_abbreviation or schedule.away_team_abbreviation.';
-COMMENT ON COLUMN main.box_scores.period IS 'Game period: 1-4 for quarters, 5+ for OT, FullGame for aggregated totals.';
-COMMENT ON COLUMN main.box_scores.minutes IS 'Playing time in MM:SS format.';
-COMMENT ON COLUMN main.box_scores.starter IS 'Starter flag: 1=starter, 0=bench. Only set on FullGame rows; NULL for per-period rows.';
-
-COMMENT ON TABLE main.ingestion_log IS 'Tracks which games have been ingested and their outcome. Grain: game_id.';
-COMMENT ON COLUMN main.ingestion_log.ingestion_status IS 'Outcome of the ingestion attempt: success or error. Renamed from status to avoid ambiguity.';
-
-COMMENT ON TABLE main.data_quality_quarantine IS 'Detected data anomalies pending review. Grain: (game_id, entity_id, detection_type).';
-COMMENT ON COLUMN main.data_quality_quarantine.resolution_status IS 'Review status: pending, approved, or rejected. Renamed from status to avoid ambiguity.';
-
-COMMENT ON VIEW main.team_stats IS 'Aggregated team stats per game per period. Derived from box_scores via SUM.';
-COMMENT ON COLUMN main.team_stats.team_abbreviation IS 'Three-letter team code. Joins to schedule.home_team_abbreviation or schedule.away_team_abbreviation.';
-
-COMMENT ON VIEW main.players IS 'Distinct player dimension derived from FullGame box_scores rows.';
-`;
+// Schema comments are now generated dynamically by metadata-generator
+// after ingest. See scripts/ingest/db/metadata.ts and `npm run metadata:refresh`.
 
 export const ALL_DDL = [
   CREATE_SCHEDULE,
@@ -155,5 +131,4 @@ export const ALL_DDL = [
   CREATE_DATA_QUALITY_QUARANTINE,
   CREATE_TEAM_STATS_VIEW,
   CREATE_PLAYERS_VIEW,
-  SCHEMA_COMMENTS,
 ] as const;

--- a/scripts/ingest/index.ts
+++ b/scripts/ingest/index.ts
@@ -9,6 +9,7 @@ import { processSeason } from './workers/season-worker';
 import { runPool } from './workers/pool';
 import { shutdownSignal } from './util/shutdown';
 import { logger } from './util/logger';
+import { refreshMetadata } from './db/metadata';
 import type { SeasonProgress } from './types';
 
 async function main(): Promise<void> {
@@ -94,6 +95,11 @@ async function main(): Promise<void> {
     if (!config.dryRun && !shutdownSignal.aborted) {
       logger.info('Refreshing team_stats view...');
       await loader.deriveTeamStats();
+    }
+
+    // Refresh dynamic metadata comments (unless dry-run)
+    if (!config.dryRun && !shutdownSignal.aborted) {
+      await refreshMetadata(config.database);
     }
 
     // Print summary


### PR DESCRIPTION
## Summary
- Replace hardcoded `SCHEMA_COMMENTS` in `schema.ts` with dynamic metadata generation via `metadata-generator`
- Add post-ingest step that profiles the database and applies `COMMENT ON` statements with real facts (row counts, value ranges, FK relationships, null rates)
- Add `npm run metadata:refresh` for standalone use
- Non-fatal: if `metadata-generator` is unavailable, ingest still completes

Closes #50

## Test plan
- [ ] Run `npm run metadata:refresh` — verify 156 comments applied
- [ ] Run `npm run ingest:current` — verify metadata step runs at end
- [ ] Check MotherDuck UI for column/table comments on `nba_box_scores_v2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)