### PR TITLE
Add game_quality view to v2 schema

### DIFF
--- a/scripts/ingest/db/schema.ts
+++ b/scripts/ingest/db/schema.ts
@@ -122,6 +122,109 @@ SELECT DISTINCT entity_id, player_name
 FROM nba_box_scores_v2.main.box_scores
 WHERE period = 'FullGame';`;
 
+export const CREATE_GAME_QUALITY_VIEW = `
+CREATE OR REPLACE VIEW main.game_quality AS
+WITH cte_schedule AS MATERIALIZED (
+  SELECT
+    CAST(yearweek(CAST(timezone('America/New_York', timezone('UTC', game_date)) AS DATE)) AS INTEGER) AS week_id,
+    game_id
+  FROM nba_box_scores_v2.main.schedule
+),
+cte_box_score_cnt AS (
+  SELECT s.week_id, COUNT(*) AS gm_count
+  FROM nba_box_scores_v2.main.box_scores bs
+  INNER JOIN cte_schedule s ON bs.game_id = s.game_id
+  WHERE bs.period = 'FullGame'
+    AND CAST(substring(bs.minutes, 1, instr(bs.minutes, ':') - 1) AS INTEGER) >= 15
+  GROUP BY ALL
+),
+cte_prep AS MATERIALIZED (
+  SELECT
+    bs.game_id,
+    bs.entity_id,
+    bs.player_name,
+    CASE WHEN bs.fg_attempted > 0 THEN round(CAST(bs.fg_made AS DOUBLE) / bs.fg_attempted, 3) ELSE 0 END AS fg_pct,
+    CASE WHEN bs.ft_attempted > 0 THEN round(CAST(bs.ft_made AS DOUBLE) / bs.ft_attempted, 3) ELSE 0 END AS ft_pct,
+    round((fg_pct - 0.47) * bs.fg_attempted, 2) AS fg_v,
+    round((ft_pct - 0.80) * bs.ft_attempted, 2) AS ft_v,
+    bs.fg3_made,
+    bs.points,
+    bs.rebounds,
+    bs.assists,
+    bs.steals,
+    bs.blocks,
+    bs.turnovers,
+    s.week_id
+  FROM nba_box_scores_v2.main.box_scores bs
+  INNER JOIN cte_schedule s ON bs.game_id = s.game_id
+  WHERE bs.period = 'FullGame'
+    AND CAST(substring(bs.minutes, 1, instr(bs.minutes, ':') - 1) AS INTEGER) >= 15
+  ORDER BY week_id, entity_id
+),
+cte_missing_games AS (
+  SELECT
+    bs.game_id,
+    bs.entity_id,
+    bs.player_name,
+    CASE WHEN bs.fg_attempted > 0 THEN round(CAST(bs.fg_made AS DOUBLE) / bs.fg_attempted, 3) ELSE 0 END AS fg_pct,
+    CASE WHEN bs.ft_attempted > 0 THEN round(CAST(bs.ft_made AS DOUBLE) / bs.ft_attempted, 3) ELSE 0 END AS ft_pct,
+    round((fg_pct - 0.47) * bs.fg_attempted, 2) AS fg_v,
+    round((ft_pct - 0.80) * bs.ft_attempted, 2) AS ft_v,
+    bs.fg3_made,
+    bs.points,
+    bs.rebounds,
+    bs.assists,
+    bs.steals,
+    bs.blocks,
+    bs.turnovers,
+    s.week_id
+  FROM nba_box_scores_v2.main.box_scores bs
+  INNER JOIN cte_schedule s ON bs.game_id = s.game_id
+  WHERE bs.period = 'FullGame'
+    AND CAST(substring(bs.minutes, 1, instr(bs.minutes, ':') - 1) AS INTEGER) < 15
+),
+cte_final AS (
+  (
+    SELECT
+      base.*,
+      CAST(SUM(CAST(
+        (CAST(base.fg_v > comp.fg_v AS INTEGER)
+        + CAST(base.ft_v > comp.ft_v AS INTEGER)
+        + CAST(base.fg3_made > comp.fg3_made AS INTEGER)
+        + CAST(base.points > comp.points AS INTEGER)
+        + CAST(base.rebounds > comp.rebounds AS INTEGER)
+        + CAST(base.assists > comp.assists AS INTEGER)
+        + CAST(base.steals > comp.steals AS INTEGER)
+        + CAST(base.blocks > comp.blocks AS INTEGER)
+        + CAST(base.turnovers < comp.turnovers AS INTEGER)
+        + (CAST(base.fg_v = comp.fg_v AS INTEGER)
+          + CAST(base.ft_v = comp.ft_v AS INTEGER)
+          + CAST(base.fg3_made = comp.fg3_made AS INTEGER)
+          + CAST(base.points = comp.points AS INTEGER)
+          + CAST(base.rebounds = comp.rebounds AS INTEGER)
+          + CAST(base.assists = comp.assists AS INTEGER)
+          + CAST(base.steals = comp.steals AS INTEGER)
+          + CAST(base.blocks = comp.blocks AS INTEGER)
+          + CAST(base.turnovers = comp.turnovers AS INTEGER))
+          * 0.5
+        ) > 4.5 AS INTEGER)) AS INTEGER) AS wins,
+      bsc.gm_count
+    FROM cte_prep base
+    LEFT JOIN cte_prep comp ON comp.entity_id != base.entity_id AND comp.week_id = base.week_id
+    LEFT JOIN cte_box_score_cnt bsc ON bsc.week_id = base.week_id
+    GROUP BY ALL
+  )
+  UNION ALL
+  (
+    SELECT mg.*, -1 AS wins, bsc.gm_count
+    FROM cte_missing_games mg
+    LEFT JOIN cte_box_score_cnt bsc ON bsc.week_id = mg.week_id
+  )
+)
+SELECT *,
+  CASE WHEN wins != -1 THEN round(CAST(wins AS DOUBLE) / gm_count, 4) ELSE -1 END AS game_quality
+FROM cte_final;`;
+
 // Schema comments are now generated dynamically by metadata-generator
 // after ingest. See scripts/ingest/db/metadata.ts and `npm run metadata:refresh`.
 
@@ -132,4 +235,5 @@ export const ALL_DDL = [
   CREATE_DATA_QUALITY_QUARANTINE,
   CREATE_TEAM_STATS_VIEW,
   CREATE_PLAYERS_VIEW,
+  CREATE_GAME_QUALITY_VIEW,
 ] as const;


### PR DESCRIPTION
## Summary
- Port the v1 `box_scores_gq` view as a single canonical `game_quality` view in v2
- Consolidates the 3 confusing v1 objects (`box_score_gq`, `box_score_gq_v2`, `box_scores_gq`) into one view
- Fixes HUGEINT type issue with explicit INTEGER/DOUBLE casts
- View is already live on MotherDuck and verified (SGA, Jokic, Haliburton at top)

Partially addresses #50

## Test plan
- [x] View created on MotherDuck, returns correct results
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)