### PR TITLE
Add raw PBPStats data lake and hydration pipeline

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -159,3 +159,34 @@
 - **GitHub Actions workflows**: 3 (nightly, hourly, backfill)
 - **Chart components**: 3 (PlayerPerformanceTrend, TeamComparisonChart, GameQualityDistribution)
 - **Python/legacy files removed**: ~10 files + entire `src/nba_box_scores/` directory
+
+## Raw Data Lake
+
+### 2026-03-04 — Raw PBPStats JSON storage (raw_game_data_pbpstats)
+
+**Problem**: The PBPStats API returns 90+ fields per player per period, but `box_scores` only captures 19 columns. Re-fetching a full season takes ~90 minutes due to API rate limits. Every time we want a new analytic (shot quality, possessions, usage rate), we'd need a full re-fetch.
+
+**Decision**: Store the complete raw API response in a `raw_game_data_pbpstats` table. This makes `box_scores` a derived data mart that can be regenerated at any time without re-fetching from the API.
+
+**Why this table name**: Named `raw_game_data_pbpstats` (not generic `raw_game_data`) because multiple raw sources are planned — `raw_game_data_nba` for pre-2000 data via the NBA API (issue #30). Each source gets its own raw table.
+
+**Schema design**:
+- `game_json` stores the `game` object (metadata, arena, teams)
+- `box_score_json` stores `boxScore.stats` (all player stats per period — the expensive part)
+- `season_year`/`season_type` denormalized for efficient filtering during hydration
+- `source_version` nullable, for future API version tracking
+
+**Why DELETE + INSERT for hydration (not INSERT OR REPLACE)**:
+- Row counts can change if parser logic evolves (e.g., new periods, different entity handling)
+- DELETE + INSERT is a clean slate per game — no stale rows left behind
+- Matches the standard "drop and reload" pattern in data warehousing
+
+**Storage estimate**: ~1.1 GB raw JSON for all ~4,684 games; DuckDB compresses to ~250-350 MB.
+
+**New scripts**:
+- `npm run raw:backfill` — loads ~2,178 games from local `data/box_scores/` cache
+- `npm run hydrate -- --season 2024` — re-derives `box_scores` from raw JSON
+- Season worker now stores raw JSON automatically during normal ingestion
+
+**Files changed**: `schema.ts`, `loader.ts`, `season-worker.ts`, `package.json`
+**Files created**: `backfill-raw.ts`, `hydrate.ts`

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "data-quality:check": "tsx scripts/data-quality/check.ts",
     "data-quality:re-audit": "tsx scripts/data-quality/check.ts --re-audit",
     "data-quality:issues": "tsx scripts/data-quality/github-issues.ts",
+    "raw:backfill": "tsx scripts/ingest/backfill-raw.ts",
+    "hydrate": "tsx scripts/ingest/hydrate.ts",
     "metadata:refresh": "cd ~/code/metadata_generator && uv run metadata-generator --database nba_box_scores_v2 comments main -x --refresh"
   },
   "dependencies": {

--- a/scripts/ingest/backfill-raw.ts
+++ b/scripts/ingest/backfill-raw.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env tsx
+// One-time backfill: load raw JSON from local data/box_scores/ cache
+// into the raw_game_data_pbpstats table.
+//
+// Usage: npm run raw:backfill
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { MotherDuckConnection } from './db/connection';
+import { Loader } from './db/loader';
+import { getSeasonType, getSeasonYear } from './parse/season-utils';
+import { logger } from './util/logger';
+
+const DATA_DIR = path.resolve(__dirname, '../../data/box_scores');
+const BATCH_SIZE = 50;
+
+async function main(): Promise<void> {
+  const token = process.env.MOTHERDUCK_TOKEN;
+  if (!token) {
+    logger.error('MOTHERDUCK_TOKEN environment variable is required');
+    process.exit(1);
+  }
+
+  const db = new MotherDuckConnection(token);
+  await db.connect();
+  const loader = new Loader(db);
+
+  try {
+    await loader.ensureSchema();
+
+    // Glob JSON files
+    const files = fs.readdirSync(DATA_DIR).filter((f) => f.endsWith('.json'));
+    logger.info('Found local JSON files', { count: files.length, dir: DATA_DIR });
+
+    if (files.length === 0) {
+      logger.info('No files to backfill');
+      return;
+    }
+
+    let loaded = 0;
+    let errors = 0;
+
+    for (let i = 0; i < files.length; i += BATCH_SIZE) {
+      const batch = files.slice(i, i + BATCH_SIZE);
+
+      for (const file of batch) {
+        try {
+          const filePath = path.join(DATA_DIR, file);
+          const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+          const gameId = raw.game.gameId as string;
+          const gameDateEst = raw.game.gameDateEst as string;
+          const seasonYear = getSeasonYear(gameDateEst);
+          const seasonType = getSeasonType(gameId);
+
+          await loader.storeRawPbpstats(
+            gameId,
+            seasonYear,
+            seasonType,
+            raw.game,
+            raw.boxScore.stats,
+          );
+
+          loaded++;
+        } catch (err) {
+          errors++;
+          logger.error('Failed to backfill file', {
+            file,
+            error: (err as Error).message,
+          });
+        }
+      }
+
+      logger.progress(`Backfilled ${loaded}/${files.length} files (${errors} errors)`);
+    }
+
+    // Clear the progress line
+    if (process.stdout.isTTY) {
+      process.stdout.write('\n');
+    }
+
+    logger.info('Backfill complete', { loaded, errors, total: files.length });
+  } finally {
+    db.close();
+  }
+}
+
+main().catch((err) => {
+  logger.error('Backfill failed', { error: (err as Error).message });
+  process.exit(1);
+});

--- a/scripts/ingest/db/loader.ts
+++ b/scripts/ingest/db/loader.ts
@@ -143,6 +143,22 @@ export class Loader {
     return new Set(rows.map((r) => r.game_id));
   }
 
+  /** Insert or replace a raw PBPStats game into the raw data lake */
+  async storeRawPbpstats(
+    gameId: string,
+    seasonYear: number,
+    seasonType: string,
+    gameJson: unknown,
+    boxScoreJson: unknown,
+  ): Promise<void> {
+    await this.db.execute(
+      `INSERT OR REPLACE INTO main.raw_game_data_pbpstats
+       (game_id, season_year, season_type, game_json, box_score_json)
+       VALUES (${esc(gameId)}, ${num(seasonYear)}, ${esc(seasonType)},
+               ${esc(JSON.stringify(gameJson))}, ${esc(JSON.stringify(boxScoreJson))})`,
+    );
+  }
+
   /** Recreate the team_stats view from the schema DDL */
   async deriveTeamStats(): Promise<void> {
     await this.db.execute(CREATE_TEAM_STATS_VIEW);

--- a/scripts/ingest/db/schema.ts
+++ b/scripts/ingest/db/schema.ts
@@ -225,6 +225,17 @@ SELECT *,
   CASE WHEN wins != -1 THEN round(CAST(wins AS DOUBLE) / gm_count, 4) ELSE -1 END AS game_quality
 FROM cte_final;`;
 
+export const CREATE_RAW_GAME_DATA_PBPSTATS = `
+CREATE TABLE IF NOT EXISTS main.raw_game_data_pbpstats (
+  game_id TEXT PRIMARY KEY,
+  season_year INTEGER NOT NULL,
+  season_type TEXT NOT NULL,
+  game_json JSON NOT NULL,
+  box_score_json JSON NOT NULL,
+  source_version TEXT,
+  ingested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);`;
+
 // Schema comments are now generated dynamically by metadata-generator
 // after ingest. See scripts/ingest/db/metadata.ts and `npm run metadata:refresh`.
 
@@ -233,6 +244,7 @@ export const ALL_DDL = [
   CREATE_BOX_SCORES,
   CREATE_INGESTION_LOG,
   CREATE_DATA_QUALITY_QUARANTINE,
+  CREATE_RAW_GAME_DATA_PBPSTATS,
   CREATE_TEAM_STATS_VIEW,
   CREATE_PLAYERS_VIEW,
   CREATE_GAME_QUALITY_VIEW,

--- a/scripts/ingest/hydrate.ts
+++ b/scripts/ingest/hydrate.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env tsx
+// Re-derive box_scores from raw JSON stored in raw_game_data_pbpstats.
+//
+// Uses DELETE + INSERT (not INSERT OR REPLACE) because row counts can
+// change if parser logic evolves — clean slate per game avoids stale rows.
+//
+// Usage:
+//   npm run hydrate -- --season 2024
+//   npm run hydrate -- --game 0022400001
+//   npm run hydrate -- --all
+
+import { MotherDuckConnection } from './db/connection';
+import { Loader } from './db/loader';
+import { parseBoxScore } from './parse/box-score-parser';
+import { logger } from './util/logger';
+
+const BATCH_SIZE = 50;
+
+/** Escape a SQL string value (single quotes) */
+function esc(val: string): string {
+  return `'${val.replace(/'/g, "''")}'`;
+}
+
+interface RawRow {
+  game_id: string;
+  game_json: string;
+  box_score_json: string;
+}
+
+function parseArgs(): { mode: 'season'; season: number } | { mode: 'game'; gameId: string } | { mode: 'all' } {
+  const args = process.argv.slice(2);
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--season' && args[i + 1]) {
+      return { mode: 'season', season: parseInt(args[i + 1], 10) };
+    }
+    if (args[i] === '--game' && args[i + 1]) {
+      return { mode: 'game', gameId: args[i + 1] };
+    }
+    if (args[i] === '--all') {
+      return { mode: 'all' };
+    }
+  }
+
+  console.error('Usage: hydrate --season <year> | --game <gameId> | --all');
+  process.exit(1);
+}
+
+/** Split an array into chunks of the given size */
+function chunk<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
+async function main(): Promise<void> {
+  const token = process.env.MOTHERDUCK_TOKEN;
+  if (!token) {
+    logger.error('MOTHERDUCK_TOKEN environment variable is required');
+    process.exit(1);
+  }
+
+  const config = parseArgs();
+
+  const db = new MotherDuckConnection(token);
+  await db.connect();
+  const loader = new Loader(db);
+
+  try {
+    await loader.ensureSchema();
+
+    // 1. Get the list of game IDs to hydrate
+    let gameIds: string[];
+
+    if (config.mode === 'season') {
+      const rows = await db.query<{ game_id: string }>(
+        `SELECT game_id FROM main.raw_game_data_pbpstats
+         WHERE season_year = ${config.season}
+         ORDER BY game_id`,
+      );
+      gameIds = rows.map((r) => r.game_id);
+      logger.info('Hydrating season', { season: config.season, games: gameIds.length });
+    } else if (config.mode === 'game') {
+      gameIds = [config.gameId];
+      logger.info('Hydrating single game', { gameId: config.gameId });
+    } else {
+      const rows = await db.query<{ game_id: string }>(
+        `SELECT game_id FROM main.raw_game_data_pbpstats ORDER BY game_id`,
+      );
+      gameIds = rows.map((r) => r.game_id);
+      logger.info('Hydrating all games', { games: gameIds.length });
+    }
+
+    if (gameIds.length === 0) {
+      logger.info('No games found to hydrate');
+      return;
+    }
+
+    // 2. Process in batches
+    let processed = 0;
+    let errors = 0;
+    const batches = chunk(gameIds, BATCH_SIZE);
+
+    for (const batch of batches) {
+      const inClause = batch.map((id) => esc(id)).join(',');
+
+      // Fetch raw JSON for this batch
+      const rawRows = await db.query<RawRow>(
+        `SELECT game_id, game_json, box_score_json
+         FROM main.raw_game_data_pbpstats
+         WHERE game_id IN (${inClause})`,
+      );
+
+      // DELETE existing box_scores for these games (clean slate)
+      await db.execute(
+        `DELETE FROM main.box_scores WHERE game_id IN (${inClause})`,
+      );
+
+      // Re-parse all games in this batch, then INSERT in one call
+      const allRows: Awaited<ReturnType<typeof parseBoxScore>> = [];
+      for (const raw of rawRows) {
+        try {
+          // DuckDB returns JSON columns as strings — parse them
+          const gameJson = typeof raw.game_json === 'string'
+            ? JSON.parse(raw.game_json)
+            : raw.game_json;
+          const boxScoreJson = typeof raw.box_score_json === 'string'
+            ? JSON.parse(raw.box_score_json)
+            : raw.box_score_json;
+
+          const gameData = {
+            game: gameJson,
+            boxScore: { stats: boxScoreJson },
+          };
+
+          allRows.push(...parseBoxScore(gameData));
+          processed++;
+        } catch (err) {
+          errors++;
+          logger.error('Failed to hydrate game', {
+            gameId: raw.game_id,
+            error: (err as Error).message,
+          });
+        }
+      }
+
+      // Batch insert all rows for this chunk (loadBoxScoreRows handles internal batching at 500)
+      if (allRows.length > 0) {
+        await loader.loadBoxScoreRows(allRows);
+      }
+
+      logger.progress(`Hydrated ${processed}/${gameIds.length} games (${errors} errors)`);
+    }
+
+    // Clear the progress line
+    if (process.stdout.isTTY) {
+      process.stdout.write('\n');
+    }
+
+    // 3. Reset audited_at so data quality checks re-run on hydrated games
+    if (gameIds.length > 0) {
+      // Process in batches to avoid SQL length limits
+      for (const batch of batches) {
+        const inClause = batch.map((id) => esc(id)).join(',');
+        await db.execute(
+          `UPDATE main.ingestion_log SET audited_at = NULL
+           WHERE game_id IN (${inClause})`,
+        );
+      }
+      logger.info('Reset audited_at for hydrated games');
+    }
+
+    logger.info('Hydration complete', { processed, errors, total: gameIds.length });
+  } finally {
+    db.close();
+  }
+}
+
+main().catch((err) => {
+  logger.error('Hydration failed', { error: (err as Error).message });
+  process.exit(1);
+});

--- a/scripts/ingest/workers/season-worker.ts
+++ b/scripts/ingest/workers/season-worker.ts
@@ -162,6 +162,12 @@ export async function processSeason(
         },
       };
 
+      // Store full raw JSON for the data lake before parsing
+      await loader.storeRawPbpstats(
+        gameId, seasonYear, seasonType,
+        rawGameData.game, rawGameData.boxScore.stats,
+      );
+
       const rows = parseBoxScore(rawGameData);
       await loader.loadBoxScoreRows(rows);
       await loader.markIngested({


### PR DESCRIPTION
## Summary

- Add `raw_game_data_pbpstats` table to store full PBPStats API JSON (90+ fields/player vs 19 in `box_scores`)
- Store raw JSON automatically during ingestion so we never need to re-fetch to add new analytics
- Add `backfill-raw.ts` to populate from local JSON cache (~2,178 games)
- Add `hydrate.ts` to re-derive `box_scores` from raw JSON (supports `--season`, `--game`, `--all`)
- Hydrate uses batched DELETE + INSERT for performance (related: #97)

## Test plan

- [x] `npm run build` passes
- [x] Tests unchanged (91/94 baseline)
- [ ] `npm run raw:backfill` loads local JSON cache (in progress)
- [ ] `SELECT COUNT(*) FROM raw_game_data_pbpstats` matches file count
- [ ] `npm run hydrate -- --season 2024` re-derives box_scores correctly
- [ ] `npm run ingest:current` stores raw JSON for new games

🤖 Generated with [Claude Code](https://claude.com/claude-code)