### PR TITLE
Add --fill-raw flag for backfilling raw JSON

### DIFF
--- a/scripts/ingest/config.ts
+++ b/scripts/ingest/config.ts
@@ -17,6 +17,7 @@ Options:
   --max-delay <ms>              Maximum delay (adaptive cap)    [default: 10000]
   --season-concurrency <n>      Parallel season workers         [default: 1]
   --force                       Re-ingest even if already logged
+  --fill-raw                    Only fetch raw JSON for games missing it
   --dry-run                     Log actions without writing to DB
   --verbose                     Enable debug-level logging
   --help                        Show this help message
@@ -50,6 +51,7 @@ export function buildConfig(args: string[] = process.argv.slice(2)): PipelineCon
   let maxDelay = 10_000;
   let seasonConcurrency = 1;
   let force = false;
+  let fillRaw = false;
   let dryRun = false;
   let verbose = false;
 
@@ -141,6 +143,9 @@ export function buildConfig(args: string[] = process.argv.slice(2)): PipelineCon
       case '--force':
         force = true;
         break;
+      case '--fill-raw':
+        fillRaw = true;
+        break;
       case '--dry-run':
         dryRun = true;
         break;
@@ -197,6 +202,7 @@ export function buildConfig(args: string[] = process.argv.slice(2)): PipelineCon
     maxDelay,
     seasonConcurrency,
     force,
+    fillRaw,
     dryRun,
     verbose,
     motherDuckToken,

--- a/scripts/ingest/db/loader.ts
+++ b/scripts/ingest/db/loader.ts
@@ -143,6 +143,16 @@ export class Loader {
     return new Set(rows.map((r) => r.game_id));
   }
 
+  /** Get all game IDs that already have raw JSON for a season */
+  async getRawGameIds(seasonYear: number, seasonType: string): Promise<Set<string>> {
+    const rows = await this.db.query<{ game_id: string }>(
+      `SELECT game_id FROM main.raw_game_data_pbpstats
+       WHERE season_year = ${num(seasonYear)}
+         AND season_type = ${esc(seasonType)}`,
+    );
+    return new Set(rows.map((r) => r.game_id));
+  }
+
   /** Insert or replace a raw PBPStats game into the raw data lake */
   async storeRawPbpstats(
     gameId: string,

--- a/scripts/ingest/types.ts
+++ b/scripts/ingest/types.ts
@@ -122,6 +122,7 @@ export interface PipelineConfig {
   maxDelay: number;
   seasonConcurrency: number;
   force: boolean;
+  fillRaw: boolean;
   dryRun: boolean;
   verbose: boolean;
   motherDuckToken: string;

--- a/scripts/ingest/workers/season-worker.ts
+++ b/scripts/ingest/workers/season-worker.ts
@@ -64,13 +64,19 @@ export async function processSeason(
   }
 
   // 2. Check which games are already ingested (for incremental skip)
-  const ingestedIds = config.force
-    ? new Set<string>()
-    : await loader.getIngestedGameIds(seasonYear, seasonType);
+  let skipIds: Set<string>;
+  if (config.force) {
+    skipIds = new Set<string>();
+  } else if (config.fillRaw) {
+    // In fill-raw mode, skip games that already have raw JSON
+    skipIds = await loader.getRawGameIds(seasonYear, seasonType);
+  } else {
+    skipIds = await loader.getIngestedGameIds(seasonYear, seasonType);
+  }
 
   // 3. Filter to games that need processing
   const gamesToProcess = games.filter((g) => {
-    if (ingestedIds.has(g.GameId)) {
+    if (skipIds.has(g.GameId)) {
       progress.skipped++;
       return false;
     }
@@ -168,14 +174,17 @@ export async function processSeason(
         rawGameData.game, rawGameData.boxScore.stats,
       );
 
-      const rows = parseBoxScore(rawGameData);
-      await loader.loadBoxScoreRows(rows);
-      await loader.markIngested({
-        game_id: gameId,
-        season_year: seasonYear,
-        season_type: seasonType,
-        ingestion_status: 'success',
-      });
+      // In fill-raw mode, only store raw JSON — skip box_scores and ingestion_log
+      if (!config.fillRaw) {
+        const rows = parseBoxScore(rawGameData);
+        await loader.loadBoxScoreRows(rows);
+        await loader.markIngested({
+          game_id: gameId,
+          season_year: seasonYear,
+          season_type: seasonType,
+          ingestion_status: 'success',
+        });
+      }
 
       progress.completed++;
       logProgress();


### PR DESCRIPTION
## Summary

- Add `--fill-raw` flag to the ingest pipeline to fetch raw JSON only for games missing from `raw_game_data_pbpstats`
- Skips box_scores loading and ingestion_log updates since those already exist
- Add `getRawGameIds()` to loader for efficient skip-set lookup

## Usage

```
npm run ingest -- --season 2025 --fill-raw
```

## Context

After adding the raw data lake (#98), games ingested before that PR have box_scores but no raw JSON. Running `--fill-raw` fetches from the API and stores only the raw JSON for those gaps — without re-processing existing data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)