### PR TITLE
Rewrite hydration as server-side SQL

### DIFF
--- a/scripts/ingest/db/hydration-sql.ts
+++ b/scripts/ingest/db/hydration-sql.ts
@@ -1,0 +1,174 @@
+// SQL-based hydration: derives box_scores rows from raw_game_data_pbpstats JSON
+// using DuckDB's JSON_EXTRACT, UNNEST, and aggregate functions.
+//
+// This replaces the TypeScript parse loop (box-score-parser.ts) with a single
+// INSERT ... SELECT that runs entirely server-side in MotherDuck.
+
+/**
+ * Build the SQL to hydrate box_scores from raw JSON.
+ *
+ * @param gameFilter - A SQL WHERE clause fragment to scope which games to
+ *   hydrate, e.g. `r.game_id = '0022400001'` or `r.season_year = 2024`
+ *   or `TRUE` for all games.
+ */
+export function buildHydrationSQL(gameFilter: string): string {
+  return `
+-- ── Per-period rows (quarters + OT) ─────────────────────────────
+WITH sides AS (
+  SELECT
+    r.game_id,
+    json_extract_string(r.game_json, '$.homeTeam.teamTricode') AS home_abbr,
+    json_extract_string(r.game_json, '$.awayTeam.teamTricode') AS away_abbr,
+    unnest(['Away', 'Home']) AS side,
+    r.box_score_json
+  FROM main.raw_game_data_pbpstats r
+  WHERE ${gameFilter}
+),
+with_team AS (
+  SELECT
+    s.game_id,
+    s.side,
+    CASE WHEN s.side = 'Home' THEN s.home_abbr ELSE s.away_abbr END AS team_abbreviation,
+    s.box_score_json
+  FROM sides s
+),
+with_periods AS (
+  SELECT
+    wt.game_id,
+    wt.team_abbreviation,
+    unnest(json_keys(json_extract(wt.box_score_json, '$.' || wt.side))) AS period_key,
+    wt.side,
+    wt.box_score_json
+  FROM with_team wt
+),
+period_players AS (
+  SELECT
+    wp.game_id,
+    wp.team_abbreviation,
+    wp.period_key AS period,
+    unnest(
+      from_json(
+        json_extract(wp.box_score_json, '$.' || wp.side || '."' || wp.period_key || '"'),
+        '["json"]'
+      )
+    ) AS player_json
+  FROM with_periods wp
+  WHERE wp.period_key != 'FullGame'
+),
+-- Extract per-period stats from JSON (skip entity_id = '0' team aggregates)
+per_period AS (
+  SELECT
+    game_id,
+    team_abbreviation,
+    json_extract_string(player_json, '$.EntityId') AS entity_id,
+    json_extract_string(player_json, '$.Name') AS player_name,
+    period,
+    json_extract_string(player_json, '$.Minutes') AS minutes,
+    COALESCE(CAST(json_extract(player_json, '$.Points') AS INTEGER), 0) AS points,
+    CASE
+      WHEN json_extract(player_json, '$.Rebounds') IS NOT NULL
+        THEN COALESCE(CAST(json_extract(player_json, '$.Rebounds') AS INTEGER), 0)
+      ELSE COALESCE(CAST(json_extract(player_json, '$.OffRebounds') AS INTEGER), 0)
+           + COALESCE(CAST(json_extract(player_json, '$.DefRebounds') AS INTEGER), 0)
+    END AS rebounds,
+    COALESCE(CAST(json_extract(player_json, '$.Assists') AS INTEGER), 0) AS assists,
+    COALESCE(CAST(json_extract(player_json, '$.Steals') AS INTEGER), 0) AS steals,
+    COALESCE(CAST(json_extract(player_json, '$.Blocks') AS INTEGER), 0) AS blocks,
+    COALESCE(CAST(json_extract(player_json, '$.Turnovers') AS INTEGER), 0) AS turnovers,
+    COALESCE(CAST(json_extract(player_json, '$.FG2M') AS INTEGER), 0)
+      + COALESCE(CAST(json_extract(player_json, '$.FG3M') AS INTEGER), 0) AS fg_made,
+    COALESCE(CAST(json_extract(player_json, '$.FG2A') AS INTEGER), 0)
+      + COALESCE(CAST(json_extract(player_json, '$.FG3A') AS INTEGER), 0) AS fg_attempted,
+    COALESCE(CAST(json_extract(player_json, '$.FG3M') AS INTEGER), 0) AS fg3_made,
+    COALESCE(CAST(json_extract(player_json, '$.FG3A') AS INTEGER), 0) AS fg3_attempted,
+    COALESCE(CAST(json_extract(player_json, '$.FtPoints') AS INTEGER), 0) AS ft_made,
+    COALESCE(CAST(json_extract(player_json, '$.FTA') AS INTEGER), 0) AS ft_attempted,
+    NULL::INTEGER AS starter
+  FROM period_players
+  WHERE json_extract_string(player_json, '$.EntityId') != '0'
+),
+
+-- ── FullGame rows: aggregate per-period data per player ──────────
+full_game_base AS (
+  SELECT
+    game_id,
+    team_abbreviation,
+    entity_id,
+    FIRST(player_name) AS player_name,
+    'FullGame' AS period,
+    -- Sum MM:SS minutes using integer division (//) to avoid rounding
+    CAST(SUM(
+      CAST(split_part(minutes, ':', 1) AS INTEGER) * 60
+      + CAST(split_part(minutes, ':', 2) AS INTEGER)
+    ) // 60 AS VARCHAR)
+    || ':'
+    || LPAD(CAST(SUM(
+      CAST(split_part(minutes, ':', 1) AS INTEGER) * 60
+      + CAST(split_part(minutes, ':', 2) AS INTEGER)
+    ) % 60 AS VARCHAR), 2, '0') AS minutes,
+    CAST(SUM(points) AS INTEGER) AS points,
+    CAST(SUM(rebounds) AS INTEGER) AS rebounds,
+    CAST(SUM(assists) AS INTEGER) AS assists,
+    CAST(SUM(steals) AS INTEGER) AS steals,
+    CAST(SUM(blocks) AS INTEGER) AS blocks,
+    CAST(SUM(turnovers) AS INTEGER) AS turnovers,
+    CAST(SUM(fg_made) AS INTEGER) AS fg_made,
+    CAST(SUM(fg_attempted) AS INTEGER) AS fg_attempted,
+    CAST(SUM(fg3_made) AS INTEGER) AS fg3_made,
+    CAST(SUM(fg3_attempted) AS INTEGER) AS fg3_attempted,
+    CAST(SUM(ft_made) AS INTEGER) AS ft_made,
+    CAST(SUM(ft_attempted) AS INTEGER) AS ft_attempted
+  FROM per_period
+  GROUP BY game_id, team_abbreviation, entity_id
+),
+
+-- ── Starter assignment: top 5 scorers per team per game ──────────
+full_game AS (
+  SELECT
+    game_id, team_abbreviation, entity_id, player_name, period, minutes,
+    points, rebounds, assists, steals, blocks, turnovers,
+    fg_made, fg_attempted, fg3_made, fg3_attempted, ft_made, ft_attempted,
+    CASE WHEN ROW_NUMBER() OVER (
+      PARTITION BY game_id, team_abbreviation
+      ORDER BY points DESC
+    ) <= 5 THEN 1 ELSE 0 END AS starter
+  FROM full_game_base
+)
+
+-- ── Combine per-period + FullGame rows ───────────────────────────
+SELECT * FROM per_period
+UNION ALL
+SELECT * FROM full_game`;
+}
+
+/**
+ * Build the DELETE statement for games about to be re-hydrated.
+ */
+export function buildDeleteSQL(gameFilter: string): string {
+  return `DELETE FROM main.box_scores WHERE game_id IN (
+    SELECT game_id FROM main.raw_game_data_pbpstats r WHERE ${gameFilter}
+  )`;
+}
+
+/**
+ * Build the INSERT ... SELECT statement that hydrates box_scores in one shot.
+ */
+export function buildInsertSQL(gameFilter: string): string {
+  return `INSERT INTO main.box_scores (
+  game_id, team_abbreviation, entity_id, player_name, period, minutes,
+  points, rebounds, assists, steals, blocks, turnovers,
+  fg_made, fg_attempted, fg3_made, fg3_attempted,
+  ft_made, ft_attempted, starter
+)
+${buildHydrationSQL(gameFilter)}`;
+}
+
+/**
+ * Build the UPDATE to reset audited_at for re-hydrated games.
+ */
+export function buildResetAuditSQL(gameFilter: string): string {
+  return `UPDATE main.ingestion_log SET audited_at = NULL
+    WHERE game_id IN (
+      SELECT game_id FROM main.raw_game_data_pbpstats r WHERE ${gameFilter}
+    )`;
+}

--- a/scripts/ingest/hydrate.ts
+++ b/scripts/ingest/hydrate.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env tsx
 // Re-derive box_scores from raw JSON stored in raw_game_data_pbpstats.
 //
-// Uses DELETE + INSERT (not INSERT OR REPLACE) because row counts can
-// change if parser logic evolves — clean slate per game avoids stale rows.
+// Uses server-side SQL (DELETE + INSERT ... SELECT) instead of pulling JSON
+// to the client, parsing in TypeScript, and pushing rows back. This is
+// dramatically faster because all JSON extraction, aggregation, and starter
+// assignment happen inside MotherDuck/DuckDB.
 //
 // Usage:
 //   npm run hydrate -- --season 2024
@@ -11,20 +13,12 @@
 
 import { MotherDuckConnection } from './db/connection';
 import { Loader } from './db/loader';
-import { parseBoxScore } from './parse/box-score-parser';
+import { buildDeleteSQL, buildInsertSQL, buildResetAuditSQL } from './db/hydration-sql';
 import { logger } from './util/logger';
-
-const BATCH_SIZE = 50;
 
 /** Escape a SQL string value (single quotes) */
 function esc(val: string): string {
   return `'${val.replace(/'/g, "''")}'`;
-}
-
-interface RawRow {
-  game_id: string;
-  game_json: string;
-  box_score_json: string;
 }
 
 function parseArgs(): { mode: 'season'; season: number } | { mode: 'game'; gameId: string } | { mode: 'all' } {
@@ -46,15 +40,6 @@ function parseArgs(): { mode: 'season'; season: number } | { mode: 'game'; gameI
   process.exit(1);
 }
 
-/** Split an array into chunks of the given size */
-function chunk<T>(arr: T[], size: number): T[][] {
-  const chunks: T[][] = [];
-  for (let i = 0; i < arr.length; i += size) {
-    chunks.push(arr.slice(i, i + size));
-  }
-  return chunks;
-}
-
 async function main(): Promise<void> {
   const token = process.env.MOTHERDUCK_TOKEN;
   if (!token) {
@@ -71,108 +56,65 @@ async function main(): Promise<void> {
   try {
     await loader.ensureSchema();
 
-    // 1. Get the list of game IDs to hydrate
-    let gameIds: string[];
+    // Build the game filter clause based on CLI args
+    let gameFilter: string;
+    let description: string;
 
     if (config.mode === 'season') {
-      const rows = await db.query<{ game_id: string }>(
-        `SELECT game_id FROM main.raw_game_data_pbpstats
-         WHERE season_year = ${config.season}
-         ORDER BY game_id`,
-      );
-      gameIds = rows.map((r) => r.game_id);
-      logger.info('Hydrating season', { season: config.season, games: gameIds.length });
+      gameFilter = `r.season_year = ${config.season}`;
+      description = `season ${config.season}`;
     } else if (config.mode === 'game') {
-      gameIds = [config.gameId];
-      logger.info('Hydrating single game', { gameId: config.gameId });
+      gameFilter = `r.game_id = ${esc(config.gameId)}`;
+      description = `game ${config.gameId}`;
     } else {
-      const rows = await db.query<{ game_id: string }>(
-        `SELECT game_id FROM main.raw_game_data_pbpstats ORDER BY game_id`,
-      );
-      gameIds = rows.map((r) => r.game_id);
-      logger.info('Hydrating all games', { games: gameIds.length });
+      gameFilter = 'TRUE';
+      description = 'all games';
     }
 
-    if (gameIds.length === 0) {
+    // Count games to hydrate
+    const countRows = await db.query<{ cnt: number }>(
+      `SELECT COUNT(*) AS cnt FROM main.raw_game_data_pbpstats r WHERE ${gameFilter}`,
+    );
+    const gameCount = countRows[0]?.cnt ?? 0;
+
+    if (gameCount === 0) {
       logger.info('No games found to hydrate');
       return;
     }
 
-    // 2. Process in batches
-    let processed = 0;
-    let errors = 0;
-    const batches = chunk(gameIds, BATCH_SIZE);
+    logger.info(`Hydrating ${description}`, { games: gameCount });
 
-    for (const batch of batches) {
-      const inClause = batch.map((id) => esc(id)).join(',');
+    // 1. DELETE existing box_scores for targeted games (clean slate)
+    const deleteSQL = buildDeleteSQL(gameFilter);
+    logger.info('Deleting existing box_scores for targeted games');
+    await db.execute(deleteSQL);
 
-      // Fetch raw JSON for this batch
-      const rawRows = await db.query<RawRow>(
-        `SELECT game_id, game_json, box_score_json
-         FROM main.raw_game_data_pbpstats
-         WHERE game_id IN (${inClause})`,
-      );
+    // 2. INSERT ... SELECT: derive box_scores from raw JSON entirely in SQL
+    const insertSQL = buildInsertSQL(gameFilter);
+    logger.info('Running SQL hydration (INSERT ... SELECT from raw JSON)');
+    const startTime = Date.now();
+    await db.execute(insertSQL);
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 
-      // DELETE existing box_scores for these games (clean slate)
-      await db.execute(
-        `DELETE FROM main.box_scores WHERE game_id IN (${inClause})`,
-      );
+    // 3. Count how many rows were inserted
+    const rowCountResult = await db.query<{ cnt: number }>(
+      `SELECT COUNT(*) AS cnt FROM main.box_scores
+       WHERE game_id IN (SELECT game_id FROM main.raw_game_data_pbpstats r WHERE ${gameFilter})`,
+    );
+    const rowCount = rowCountResult[0]?.cnt ?? 0;
 
-      // Re-parse all games in this batch, then INSERT in one call
-      const allRows: Awaited<ReturnType<typeof parseBoxScore>> = [];
-      for (const raw of rawRows) {
-        try {
-          // DuckDB returns JSON columns as strings — parse them
-          const gameJson = typeof raw.game_json === 'string'
-            ? JSON.parse(raw.game_json)
-            : raw.game_json;
-          const boxScoreJson = typeof raw.box_score_json === 'string'
-            ? JSON.parse(raw.box_score_json)
-            : raw.box_score_json;
+    logger.info('SQL hydration complete', {
+      games: gameCount,
+      rows_inserted: rowCount,
+      elapsed_seconds: elapsed,
+    });
 
-          const gameData = {
-            game: gameJson,
-            boxScore: { stats: boxScoreJson },
-          };
+    // 4. Reset audited_at so data quality checks re-run on hydrated games
+    const resetSQL = buildResetAuditSQL(gameFilter);
+    await db.execute(resetSQL);
+    logger.info('Reset audited_at for hydrated games');
 
-          allRows.push(...parseBoxScore(gameData));
-          processed++;
-        } catch (err) {
-          errors++;
-          logger.error('Failed to hydrate game', {
-            gameId: raw.game_id,
-            error: (err as Error).message,
-          });
-        }
-      }
-
-      // Batch insert all rows for this chunk (loadBoxScoreRows handles internal batching at 500)
-      if (allRows.length > 0) {
-        await loader.loadBoxScoreRows(allRows);
-      }
-
-      logger.progress(`Hydrated ${processed}/${gameIds.length} games (${errors} errors)`);
-    }
-
-    // Clear the progress line
-    if (process.stdout.isTTY) {
-      process.stdout.write('\n');
-    }
-
-    // 3. Reset audited_at so data quality checks re-run on hydrated games
-    if (gameIds.length > 0) {
-      // Process in batches to avoid SQL length limits
-      for (const batch of batches) {
-        const inClause = batch.map((id) => esc(id)).join(',');
-        await db.execute(
-          `UPDATE main.ingestion_log SET audited_at = NULL
-           WHERE game_id IN (${inClause})`,
-        );
-      }
-      logger.info('Reset audited_at for hydrated games');
-    }
-
-    logger.info('Hydration complete', { processed, errors, total: gameIds.length });
+    logger.info('Hydration complete', { games: gameCount, rows: rowCount });
   } finally {
     db.close();
   }


### PR DESCRIPTION
## Summary

- Replace slow TypeScript hydration (pull JSON → parse locally → push rows back) with server-side SQL
- New `hydration-sql.ts` builds INSERT...SELECT with JSON_EXTRACT, UNNEST, and window functions
- All JSON extraction, aggregation, minutes summing, and starter assignment run inside MotherDuck
- `hydrate.ts` simplified from 184 to 127 lines — just a CLI wrapper around 3 SQL statements

Closes #100

## Test plan

- [x] Build passes
- [x] Agent validated against multiple games including double OT — exact stat match
- [ ] Run `npm run hydrate -- --season 2024` and compare row counts with previous hydration

🤖 Generated with [Claude Code](https://claude.com/claude-code)