### PR TITLE
Add client-side player search and overnight backfill script

### DIFF
--- a/annotations.yaml
+++ b/annotations.yaml
@@ -1,0 +1,7 @@
+tables:
+  raw_game_data_pbpstats:
+    annotation: "DO NOT USE. Raw ingestion staging table containing unprocessed JSON from PBPStats API. Use box_scores, schedule, or other curated tables instead."
+  data_quality_quarantine:
+    annotation: "Data quality checks. Contains flagged records that failed validation rules during ingestion. Not generally used for NBA data questions."
+  ingestion_log:
+    annotation: "Pipeline operational metadata. Tracks which games have been ingested and their status. Not generally used for NBA data questions."

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,11 +9,11 @@ import GameCard from '@/components/GameCard';
 import SeasonFilter from '@/components/SeasonFilter';
 import { getTeamName } from '@/lib/teams';
 import { parseGameDate } from '@/lib/dateUtils';
-import { useSchedule, useBoxScores, usePlayerSearch } from '@/hooks/useGameData';
+import { useSchedule, useBoxScores, usePlayerIndex } from '@/hooks/useGameData';
 import { useDataLoader } from '@/lib/dataLoader';
 import { isPlayoffGame, getSeasonYearFromDate } from '@/lib/seasonUtils';
 import type { SeasonType } from '@/lib/seasonUtils';
-import type { GameDataFilters } from '@/hooks/useGameData';
+import type { GameDataFilters, PlayerIndexEntry } from '@/hooks/useGameData';
 import { useLiveData } from '@/lib/LiveDataContext';
 import type { LiveScoreGame } from '@/app/types/live';
 import type { Team } from '@/app/types/schema';
@@ -72,11 +72,11 @@ function HomeContent() {
   const [selectedGameId, setSelectedGameId] = useState<string | null>(null);
   const [selectedLiveGameId, setSelectedLiveGameId] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
-  const [playerGameIds, setPlayerGameIds] = useState<Set<string> | null>(null);
+  const [playerIndex, setPlayerIndex] = useState<PlayerIndexEntry[]>([]);
   const dataLoader = useDataLoader();
   const { fetchSchedule } = useSchedule();
   const { fetchBoxScores } = useBoxScores();
-  const { searchPlayerGameIds } = usePlayerSearch();
+  const { fetchPlayerIndex } = usePlayerIndex();
 
   const {
     isLive,
@@ -173,6 +173,42 @@ function HomeContent() {
     seasonType: seasonType,
   }), [season, seasonType]);
 
+  // Client-side player search: filter the in-memory index
+  const playerGameIds = useMemo(() => {
+    if (!player) return null;
+    const term = player.toLowerCase();
+    const matchingGameIds = new Set<string>();
+    for (const entry of playerIndex) {
+      if (entry.player_name.toLowerCase().includes(term)) {
+        for (const gid of entry.game_ids) {
+          matchingGameIds.add(gid);
+        }
+      }
+    }
+    return matchingGameIds;
+  }, [player, playerIndex]);
+
+  // Autocomplete suggestions for the search dropdown
+  const playerSuggestions = useMemo(() => {
+    if (!player || player.length < 2) return [];
+    const term = player.toLowerCase();
+    const seen = new Set<string>();
+    const results: Array<{ entity_id: string; player_name: string; team_abbreviation: string }> = [];
+    for (const entry of playerIndex) {
+      if (seen.has(entry.entity_id)) continue;
+      if (entry.player_name.toLowerCase().includes(term)) {
+        seen.add(entry.entity_id);
+        results.push({
+          entity_id: entry.entity_id,
+          player_name: entry.player_name,
+          team_abbreviation: entry.team_abbreviation,
+        });
+      }
+      if (results.length >= 8) break;
+    }
+    return results;
+  }, [player, playerIndex]);
+
   const filteredGamesByDate = useMemo(() => {
     if (!gamesByDate || Object.keys(gamesByDate).length === 0) return [];
 
@@ -184,7 +220,7 @@ function HomeContent() {
             if (team && game.home_team_abbreviation !== team && game.away_team_abbreviation !== team) {
               return false;
             }
-            if (playerGameIds && !playerGameIds.has(game.game_id)) {
+            if (playerGameIds && !playerGameIds.has(String(game.game_id))) {
               return false;
             }
             return true;
@@ -200,17 +236,7 @@ function HomeContent() {
     setCurrentPage(0);
   }, [team, season, seasonType, player]);
 
-  // Debounced player search
-  useEffect(() => {
-    if (!player) {
-      setPlayerGameIds(null);
-      return;
-    }
-    const timer = setTimeout(() => {
-      searchPlayerGameIds(player).then(setPlayerGameIds).catch(() => setPlayerGameIds(null));
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [player, searchPlayerGameIds]);
+  // Player index is now loaded with game data — search is client-side via useMemo above
 
   const totalPages = Math.max(1, Math.ceil(filteredGamesByDate.length / DATES_PER_PAGE));
   const paginatedDates = filteredGamesByDate.slice(
@@ -247,10 +273,12 @@ function HomeContent() {
         setError('');
 
         addLoadingMessage('Fetching game data...');
-        const [scheduleData, boxScoresData] = await Promise.all([
+        const [scheduleData, boxScoresData, playerIndexData] = await Promise.all([
           fetchSchedule(currentFilters),
-          fetchBoxScores(currentFilters)
+          fetchBoxScores(currentFilters),
+          fetchPlayerIndex(currentFilters),
         ]);
+        setPlayerIndex(playerIndexData);
         updateLoadingMessage(1);
 
         await new Promise(resolve => setTimeout(resolve, 100));
@@ -299,10 +327,12 @@ function HomeContent() {
       } else {
         // Subsequent filter changes: simpler reload without loading messages
         setLoading(true);
-        const [scheduleData, boxScoresData] = await Promise.all([
+        const [scheduleData, boxScoresData, playerIndexData] = await Promise.all([
           fetchSchedule(currentFilters),
-          fetchBoxScores(currentFilters)
+          fetchBoxScores(currentFilters),
+          fetchPlayerIndex(currentFilters),
         ]);
+        setPlayerIndex(playerIndexData);
 
         const gamesWithBoxScores = scheduleData.map((game) => {
           const hasBoxScore = !!boxScoresData[game.game_id];
@@ -347,7 +377,7 @@ function HomeContent() {
     } finally {
       setLoading(false);
     }
-  }, [dataLoader, fetchSchedule, fetchBoxScores]);
+  }, [dataLoader, fetchSchedule, fetchBoxScores, fetchPlayerIndex]);
 
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
@@ -381,7 +411,7 @@ function HomeContent() {
     <>
       <DynamicTableLoader />
       <div className="container mx-auto px-4 py-8 font-mono">
-        <SeasonFilter />
+        <SeasonFilter playerSuggestions={playerSuggestions} />
 
         {/* Live Games Section */}
         {isLive && activeLiveGames.length > 0 && (

--- a/components/SeasonFilter.tsx
+++ b/components/SeasonFilter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSearchParams, useRouter } from 'next/navigation';
-import { useCallback } from 'react';
+import { useCallback, useState, useRef, useEffect } from 'react';
 import { FunnelIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { TEAM_ABBREVIATIONS } from '@/lib/teams';
 import { getAvailableSeasons, formatSeasonLabel, getSeasonYearFromDate } from '@/lib/seasonUtils';
@@ -15,20 +15,48 @@ const SEASON_TYPES: { value: SeasonType; label: string }[] = [
 
 const availableSeasons = getAvailableSeasons();
 
+interface PlayerSuggestion {
+  entity_id: string;
+  player_name: string;
+  team_abbreviation: string;
+}
+
 interface SeasonFilterProps {
   basePath?: string;
   onFilterChange?: (filters: { season?: number; type?: SeasonType; team?: string }) => void;
+  playerSuggestions?: PlayerSuggestion[];
 }
 
-export default function SeasonFilter({ basePath = '/', onFilterChange }: SeasonFilterProps) {
+export default function SeasonFilter({ basePath = '/', onFilterChange, playerSuggestions = [] }: SeasonFilterProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const suggestionsRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const currentSeason = getSeasonYearFromDate(new Date());
   const season = searchParams?.get('season') ? Number(searchParams.get('season')) : currentSeason;
   const seasonType = (searchParams?.get('type') as SeasonType) || 'all';
   const team = searchParams?.get('team') || '';
   const player = searchParams?.get('player') || '';
+
+  // Close suggestions on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (suggestionsRef.current && !suggestionsRef.current.contains(e.target as Node) &&
+          inputRef.current && !inputRef.current.contains(e.target as Node)) {
+        setShowSuggestions(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Reset highlight when suggestions change
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [playerSuggestions]);
 
   const updateParams = useCallback((key: string, value: string) => {
     const params = new URLSearchParams(searchParams?.toString() ?? '');
@@ -91,14 +119,62 @@ export default function SeasonFilter({ basePath = '/', onFilterChange }: SeasonF
             ))}
           </select>
           <div className="relative">
-            <MagnifyingGlassIcon className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <MagnifyingGlassIcon className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 z-10" />
             <input
+              ref={inputRef}
               type="text"
               value={player}
-              onChange={(e) => updateParams('player', e.target.value)}
+              onChange={(e) => {
+                updateParams('player', e.target.value);
+                setShowSuggestions(true);
+              }}
+              onFocus={() => setShowSuggestions(true)}
+              onKeyDown={(e) => {
+                if (!showSuggestions || playerSuggestions.length === 0) return;
+                if (e.key === 'ArrowDown') {
+                  e.preventDefault();
+                  setHighlightedIndex(i => Math.min(i + 1, playerSuggestions.length - 1));
+                } else if (e.key === 'ArrowUp') {
+                  e.preventDefault();
+                  setHighlightedIndex(i => Math.max(i - 1, 0));
+                } else if (e.key === 'Enter' && highlightedIndex >= 0) {
+                  e.preventDefault();
+                  updateParams('player', playerSuggestions[highlightedIndex].player_name);
+                  setShowSuggestions(false);
+                } else if (e.key === 'Escape') {
+                  setShowSuggestions(false);
+                }
+              }}
               placeholder="Search player..."
               className="pl-7 pr-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm w-40"
+              autoComplete="off"
             />
+            {showSuggestions && playerSuggestions.length > 0 && (
+              <div
+                ref={suggestionsRef}
+                className="absolute top-full left-0 mt-1 w-64 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded shadow-lg z-50 max-h-60 overflow-y-auto"
+              >
+                {playerSuggestions.map((s, i) => (
+                  <button
+                    key={s.entity_id}
+                    className={`w-full text-left px-3 py-1.5 text-sm flex items-center justify-between ${
+                      i === highlightedIndex
+                        ? 'bg-blue-100 dark:bg-blue-900'
+                        : 'hover:bg-gray-100 dark:hover:bg-gray-700'
+                    }`}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      updateParams('player', s.player_name);
+                      setShowSuggestions(false);
+                    }}
+                    onMouseEnter={() => setHighlightedIndex(i)}
+                  >
+                    <span className="text-gray-900 dark:text-gray-100">{s.player_name}</span>
+                    <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">{s.team_abbreviation}</span>
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </div>
 

--- a/hooks/useGameData.ts
+++ b/hooks/useGameData.ts
@@ -127,23 +127,69 @@ export function useBoxScores() {
   return { fetchBoxScores };
 }
 
-export function usePlayerSearch() {
+export interface PlayerIndexEntry {
+  entity_id: string;
+  player_name: string;
+  team_abbreviation: string;
+  game_ids: string[];
+}
+
+/** Builds a player search index from flat (player, game_id) rows, grouped client-side. */
+function buildPlayerIndex(rows: Array<{ entity_id: string; player_name: string; team_abbreviation: string; game_id: string }>): PlayerIndexEntry[] {
+  const map = new Map<string, PlayerIndexEntry>();
+  for (const r of rows) {
+    const key = `${r.entity_id}|${r.team_abbreviation}`;
+    let entry = map.get(key);
+    if (!entry) {
+      entry = {
+        entity_id: String(r.entity_id),
+        player_name: String(r.player_name),
+        team_abbreviation: String(r.team_abbreviation),
+        game_ids: [],
+      };
+      map.set(key, entry);
+    }
+    entry.game_ids.push(String(r.game_id));
+  }
+  return Array.from(map.values());
+}
+
+export function usePlayerIndex() {
   const { evaluateQuery } = useMotherDuckClientState();
 
-  const searchPlayerGameIds = useCallback(async (playerName: string): Promise<Set<string>> => {
-    if (!playerName.trim()) return new Set();
+  const fetchPlayerIndex = useCallback(async (filters?: GameDataFilters): Promise<PlayerIndexEntry[]> => {
+    try {
+      let query: string;
+      if (filters?.seasonYear || (filters?.seasonType && filters.seasonType !== 'all')) {
+        const whereClause = buildSeasonWhereClause(filters, 's');
+        query = `
+          SELECT DISTINCT bs.entity_id, bs.player_name, bs.team_abbreviation, bs.game_id
+          FROM ${SOURCE_TABLES.BOX_SCORES} bs
+          JOIN ${SOURCE_TABLES.SCHEDULE} s ON bs.game_id = s.game_id
+          WHERE bs.period = 'FullGame'${whereClause}
+        `;
+      } else {
+        query = `
+          SELECT DISTINCT entity_id, player_name, team_abbreviation, game_id
+          FROM ${SOURCE_TABLES.BOX_SCORES}
+          WHERE period = 'FullGame'
+        `;
+      }
 
-    const escaped = escapeSqlString(playerName.trim());
-    const result = await evaluateQuery(`
-      SELECT DISTINCT game_id
-      FROM ${SOURCE_TABLES.BOX_SCORES}
-      WHERE LOWER(player_name) LIKE LOWER('%${escaped}%')
-        AND period = 'FullGame'
-    `);
+      const result = await evaluateQuery(query);
+      const rows = result.data.toRows() as unknown as {
+        entity_id: string;
+        player_name: string;
+        team_abbreviation: string;
+        game_id: string;
+      }[];
 
-    const rows = result.data.toRows() as unknown as { game_id: string }[];
-    return new Set(rows.map(r => r.game_id));
+      return buildPlayerIndex(rows);
+    } catch (error) {
+      console.error('Error fetching player index:', error);
+      throw error;
+    }
   }, [evaluateQuery]);
 
-  return { searchPlayerGameIds };
+  return { fetchPlayerIndex };
 }

--- a/scripts/backfill-all.sh
+++ b/scripts/backfill-all.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Overnight backfill script for all 25 NBA seasons (2000-01 through 2025-26).
+# Runs Regular Season first, then Playoffs. Safe to re-run — already-ingested
+# games are skipped automatically.
+#
+# Usage:
+#   ./scripts/backfill-all.sh              # full backfill
+#   ./scripts/backfill-all.sh --dry-run    # preview what would be ingested
+#
+# Logs are written to logs/backfill-<timestamp>.log
+# The script exits 0 if both phases succeed, 1 if either fails.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# --- Config ---
+DELAY=500
+MIN_DELAY=200
+MAX_DELAY=10000
+EXTRA_ARGS="${*:-}"
+
+# --- Logging setup ---
+mkdir -p logs
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOGFILE="logs/backfill-${TIMESTAMP}.log"
+
+log() {
+  local msg="[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+  echo "$msg" | tee -a "$LOGFILE"
+}
+
+# --- Preflight checks ---
+if [ -z "${MOTHERDUCK_TOKEN:-}" ]; then
+  echo "Error: MOTHERDUCK_TOKEN environment variable is required"
+  exit 1
+fi
+
+command -v tsx >/dev/null 2>&1 || { echo "Error: tsx not found. Run 'npm install' first."; exit 1; }
+
+log "=== NBA Historical Backfill Started ==="
+log "Log file: $LOGFILE"
+log "Extra args: ${EXTRA_ARGS:-none}"
+
+# --- Show current status ---
+log "--- Pre-backfill status ---"
+npx tsx scripts/ingest/status.ts 2>&1 | tee -a "$LOGFILE"
+
+# --- Phase 1: Regular Season ---
+log ""
+log "=========================================="
+log "PHASE 1: Regular Season (all seasons)"
+log "=========================================="
+
+PHASE1_EXIT=0
+npx tsx scripts/ingest/index.ts \
+  --all \
+  --season-type "Regular Season" \
+  --delay "$DELAY" \
+  --min-delay "$MIN_DELAY" \
+  --max-delay "$MAX_DELAY" \
+  $EXTRA_ARGS \
+  2>&1 | tee -a "$LOGFILE" || PHASE1_EXIT=$?
+
+if [ "$PHASE1_EXIT" -ne 0 ]; then
+  log "WARNING: Regular Season phase exited with code $PHASE1_EXIT (some games may have failed)"
+fi
+
+# --- Phase 2: Playoffs ---
+log ""
+log "=========================================="
+log "PHASE 2: Playoffs (all seasons)"
+log "=========================================="
+
+PHASE2_EXIT=0
+npx tsx scripts/ingest/index.ts \
+  --all \
+  --season-type "Playoffs" \
+  --delay "$DELAY" \
+  --min-delay "$MIN_DELAY" \
+  --max-delay "$MAX_DELAY" \
+  $EXTRA_ARGS \
+  2>&1 | tee -a "$LOGFILE" || PHASE2_EXIT=$?
+
+if [ "$PHASE2_EXIT" -ne 0 ]; then
+  log "WARNING: Playoffs phase exited with code $PHASE2_EXIT (some games may have failed)"
+fi
+
+# --- Post-backfill status ---
+log ""
+log "--- Post-backfill status ---"
+npx tsx scripts/ingest/status.ts 2>&1 | tee -a "$LOGFILE"
+
+# --- Summary ---
+log ""
+log "=== Backfill Complete ==="
+log "Regular Season exit code: $PHASE1_EXIT"
+log "Playoffs exit code: $PHASE2_EXIT"
+log "Full log: $LOGFILE"
+
+if [ "$PHASE1_EXIT" -ne 0 ] || [ "$PHASE2_EXIT" -ne 0 ]; then
+  log "Some games failed. Re-run this script to retry — successful games will be skipped."
+  exit 1
+fi
+
+log "All phases completed successfully!"
+exit 0


### PR DESCRIPTION
## Summary
- **Client-side search (#49)**: Replace per-keystroke SQL LIKE queries with an in-memory player index loaded once per season. Search is now sub-millisecond via `useMemo` with an autocomplete dropdown showing matching players and their team abbreviation. Keyboard navigation (arrow keys, Enter, Escape) supported.
- **Backfill script (#19)**: Add `scripts/backfill-all.sh` for overnight historical ingestion of all 25 seasons (Regular Season + Playoffs). Logs to `logs/`, safe to re-run.
- **Metadata annotations**: Add `annotations.yaml` marking raw/quarantine/ingestion_log tables as not for NBA data questions.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Existing tests pass (91/94 — 3 pre-existing failures in dataLoader.test.ts)
- [ ] Manual: type player name in search, verify autocomplete appears and selecting filters games
- [ ] Manual: team dropdown still filters independently
- [ ] Manual: `?player=` URL param still works
- [ ] Manual: `./scripts/backfill-all.sh --dry-run` previews seasons

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)